### PR TITLE
Slice 2: Lists and items

### DIFF
--- a/03-SPEC.md
+++ b/03-SPEC.md
@@ -36,9 +36,10 @@ Full column-level schema is a build-time (not spec-time) detail; this is the sha
 each slice below assumes exists.
 
 - `households`, `household_members` (user ↔ household, all members equal rank)
-- `lists` (household_id nullable — null means personal/private to owner; `type`:
-  personal | household)
-- `list_items` (list_id, name, checked, position, location_tag_id nullable)
+- `lists` (owner_id, household_id nullable — null means personal/private to owner,
+  and is the *only* record of scope; `deleted_at` nullable)
+- `list_items` (list_id, name, `checked_at` nullable, position, location_tag_id
+  nullable, `deleted_at` nullable)
 - `locations` (supermarket instances — name, lat/lng, created_by anonymized)
 - `location_items` (per-location, crowdsourced: item name → shelf/section, vote
   state)
@@ -111,7 +112,84 @@ lists are visible only to their owner even inside a household.
 **Acceptance test:** A user builds a list across multiple sessions (items added,
 none removed by app restart), a personal list is invisible to a second household
 member, a household list is visible to them (sync arrives in Slice 3 — visibility
-after manual reload is enough to pass this slice).
+after manual reload is enough to pass this slice). A user who has never joined a
+household can build a personal list, and two such users cannot see each other's.
+
+*Agreed 2026-08-10, at Protocol Step 2 — the issue was labelled "no open questions"
+and had nine. Each of these shapes the schema or the acceptance test:*
+
+- **Scope is `household_id` alone; there is no `type` column.** § 1 above lists both,
+  which is one fact stored twice with two of its four states invalid. Nothing reads
+  the second copy. The inverse (keep `type`, always store `household_id`) is
+  unavailable, because a user with no household has no id to store.
+- **The read policy compares with `=`, never `is not distinct from`.** For a user
+  with no household `current_household_id()` is null, so `household_id = null` is
+  null → false and personal lists match on ownership alone. Written with
+  `is not distinct from`, `null = null` is *true* and every householdless user sees
+  every other householdless user's lists. Same class as the § 0 invariant Slice 1
+  guarded, so it gets a policy test rather than a comment.
+- **Personal → household is allowed; household → personal is not.** Slice 1 made
+  households optional and created later, so fixing scope at creation would strand
+  every list built before pairing. Demotion is the opposite: it removes a list from
+  people who added items to it, which under Slice 3 is a list vanishing off someone's
+  screen live. The want behind it is *copy*, which Slice 9 already builds.
+  Promotion is one-way, publishes existing item text, and is confirmed before it runs.
+- **`position` is manual order only. Slice 7 never writes it.** Route order is a
+  property of list × location, computed as a sort at read time. Persisting it would
+  rewrite every row on arrival at a shop, broadcast that rewrite to the whole
+  household through Slice 3, and destroy the user's own order permanently.
+- **Order is a fractional base-62 key, sorted `order by position, id`.** A move
+  writes exactly one row and subdivision never exhausts, so no renumbering path
+  exists. Contiguous integers make a move an N-row rewrite that races whole-list
+  against whole-list under Slice 3; sparse integers and float midpoints only make
+  that rare, and Slice 1 already rejected "rare" when it retried invite-code
+  collisions. Two members moving into the same slot can compute the same key —
+  `id` breaks the tie identically on every device. That also makes the append
+  read-then-write race benign.
+- **New items append to the end, and check-off never writes `position`.** One
+  gesture, one fact. Checked items stay where they are; grouping them is a UI concern.
+- **Removal is a soft delete on both `lists` and `list_items`.** Supabase does not
+  apply RLS to `DELETE` statements ("there is no way for Postgres to verify that a
+  user has access to a deleted record"), so a hard delete broadcasts to every
+  subscriber of the table regardless of household. Only primary keys travel, but § 0
+  makes list data household-private a hard invariant, so that is not a judgement call
+  to make quietly. Soft delete makes removal an `UPDATE`, which *is* filtered — and
+  additionally gives Slice 3 one mechanism instead of two, makes undo possible, and
+  keeps Slice 9's history resolvable. Hard-deleting a list would cascade into exactly
+  the `list_items` delete storm this avoids.
+- **Writes go direct to table under RLS `with check`; only promote-to-household is an
+  RPC.** This deviates from Slice 1's write-through-RPC split deliberately. That
+  split exists for invariants RLS cannot express atomically, and Slice 2 has none —
+  "you may only write a list you can see" and "you may only create a household list
+  in *your* household" are both plain check expressions. Promotion has real
+  conditions (owner only, own household only, must be a member) and keeps its RPC.
+- **`checked_at timestamptz null` replaces the `checked` boolean** listed in § 1.
+  Strictly more information for one column; storing both would repeat the mistake
+  the first decision above corrects.
+- **Reorder ships as a plain control (move up/down), not a drag gesture.** The
+  fractional-key decision still gets exercised and tested. Real drag needs
+  `react-native-gesture-handler` and `react-native-reanimated`, neither installed,
+  and it is the first gesture code in a project where native has never been run and
+  where web drag is a different input model. Polished drag lands where it can be
+  verified on a device.
+- **Item quantities are out of spec and stay out.** `list_items` has no quantity
+  field and the CRD never asks for one. Logged in `CHANGE-LOG.md` as pending.
+- **A navigation library is adopted before any feature work in this slice** — see
+  the note below.
+
+*Navigation, revisited at Protocol Step 2 as planned:* Slice 1's branches were
+states (booting, signed out, in a household, not). Slice 2 adds a list index and a
+list detail, and detail is the first screen taking a parameter and the first with a
+real back relationship — places, not states. Hand-rolling that is genuinely small,
+but on web it means no URL, and the Vercel link is the agreed review surface: a
+tester in a list detail presses browser Back and falls out of the app. Android's
+hardware back does the same. Slices 4, 5 and 9 each add screens, so the refactor
+only gets more expensive and would otherwise land tangled in Slice 5's acceptance
+test. React Navigation (`native-stack`) is chosen over Expo Router because Expo
+Router would move the entry point and change `vercel.json`'s output config, which is
+a large blast radius on a working deploy. It lands as its own commit before any
+feature work, so a web-export break on Expo 57 / RN 0.86 / React 19.2 is isolated
+and revertable.
 
 ### Slice 3 — Real-Time Household Sync
 **Depends on:** Slice 2.

--- a/03-SPEC.md
+++ b/03-SPEC.md
@@ -128,6 +128,12 @@ and had nine. Each of these shapes the schema or the acceptance test:*
   `is not distinct from`, `null = null` is *true* and every householdless user sees
   every other householdless user's lists. Same class as the § 0 invariant Slice 1
   guarded, so it gets a policy test rather than a comment.
+- **A minimal policy-test harness is built in this slice** to make the line above
+  true. Slice 0 deferred all test infrastructure and no later slice picks it up, so
+  the promise of a test would otherwise cash out as a comment — on the one decision
+  we called invariant-class. Scope is deliberately narrow: SQL-level assertions
+  about RLS policies only (two householdless users cannot see each other; a
+  non-member cannot see a household list), not app or component tests.
 - **Personal → household is allowed; household → personal is not.** Slice 1 made
   households optional and created later, so fixing scope at creation would strand
   every list built before pairing. Demotion is the opposite: it removes a list from
@@ -146,6 +152,21 @@ and had nine. Each of these shapes the schema or the acceptance test:*
   collisions. Two members moving into the same slot can compute the same key —
   `id` breaks the tie identically on every device. That also makes the append
   read-then-write race benign.
+- **The `position` column is declared `collate "C"`.** Base-62 keys sort correctly
+  only under byte order. This database is `en_US.UTF-8` under the ICU provider,
+  where `'a1' < 'A1'` is *true* and byte order says the opposite — measured, not
+  assumed. Left to the default collation the ordering is silently wrong, and only
+  once mixed-case keys exist, which is around the sixty-third insert into one list.
+  The key generator and the column must agree on collation or neither is correct.
+- **Key generation is the `fractional-indexing` package, not hand-rolled.** CC0,
+  zero dependencies, base-62 by default. It already handles the cases a 50-line
+  version gets subtly wrong — prepending with no lower bound, appending without
+  unbounded string growth, subdividing adjacent keys, and the trailing-zero
+  invariant that keeps value and string representation one-to-one. Its failure mode
+  is not a crash but items quietly out of order weeks later on a shared list, which
+  is the worst kind of thing to own untested. Note: passing `digits` explicitly
+  yields a different keyspace than omitting it — that choice is a stored-data format
+  commitment, made once and never changed.
 - **New items append to the end, and check-off never writes `position`.** One
   gesture, one fact. Checked items stay where they are; grouping them is a UI concern.
 - **Removal is a soft delete on both `lists` and `list_items`.** Supabase does not
@@ -157,6 +178,17 @@ and had nine. Each of these shapes the schema or the acceptance test:*
   additionally gives Slice 3 one mechanism instead of two, makes undo possible, and
   keeps Slice 9's history resolvable. Hard-deleting a list would cascade into exactly
   the `list_items` delete storm this avoids.
+- **`deleted_at` is filtered in the client query, never in the RLS policy.** Realtime
+  authorises each event against the subscriber's SELECT policy evaluated on the *new*
+  row. A policy saying `deleted_at is null` would therefore filter out the very
+  UPDATE that sets it, the deletion would never reach other members, and soft delete
+  would have bought nothing — the same failure it was adopted to prevent, one layer
+  along. Filtering client-side is also correct whichever way that Realtime behaviour
+  turns out to go: Supabase documents the DELETE gap verbatim but never states the
+  UPDATE case, and confirming it needs two live subscribers, which is Slice 3's work.
+  The accepted consequence is that soft-deleted rows stay *readable* by household
+  members. That is still household-scoped so § 0 holds, but "deleted" here means
+  hidden by the client, which is a weaker claim than the word suggests.
 - **Writes go direct to table under RLS `with check`; only promote-to-household is an
   RPC.** This deviates from Slice 1's write-through-RPC split deliberately. That
   split exists for invariants RLS cannot express atomically, and Slice 2 has none —

--- a/03-SPEC.md
+++ b/03-SPEC.md
@@ -159,14 +159,20 @@ and had nine. Each of these shapes the schema or the acceptance test:*
   once mixed-case keys exist, which is around the sixty-third insert into one list.
   The key generator and the column must agree on collation or neither is correct.
 - **Key generation is the `fractional-indexing` package, not hand-rolled.** CC0,
-  zero dependencies, base-62 by default. It already handles the cases a 50-line
-  version gets subtly wrong — prepending with no lower bound, appending without
-  unbounded string growth, subdividing adjacent keys, and the trailing-zero
-  invariant that keeps value and string representation one-to-one. Its failure mode
-  is not a crash but items quietly out of order weeks later on a shared list, which
-  is the worst kind of thing to own untested. Note: passing `digits` explicitly
-  yields a different keyspace than omitting it — that choice is a stored-data format
-  commitment, made once and never changed.
+  zero dependencies. It already handles the cases a 50-line version gets subtly
+  wrong — prepending with no lower bound, appending without unbounded string
+  growth, subdividing adjacent keys, and the trailing-zero invariant that keeps
+  value and string representation one-to-one. Its failure mode is not a crash but
+  items quietly out of order weeks later on a shared list, which is the worst kind
+  of thing to own untested. **`digits` is never passed to `generateKeyBetween`,
+  anywhere, permanently.** Calling it with no third argument is not "base-62 by
+  default" as loosely stated elsewhere — the package's *value* digits default to
+  base 62, but its *integer-head* alphabet (`intDigits`) defaults to base 52 only
+  when `digits` is omitted, and to a different, self-headed base-62 scheme when
+  `digits` is passed explicitly. The two are incompatible keyspaces. Whichever one
+  a first insert uses is the stored-data format forever; the only safe rule is
+  "never pass it," not "pass base 62," because the obvious-looking fix corrupts
+  every existing key's ordering against new ones.
 - **New items append to the end, and check-off never writes `position`.** One
   gesture, one fact. Checked items stay where they are; grouping them is a UI concern.
 - **Removal is a soft delete on both `lists` and `list_items`.** Supabase does not

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -8,3 +8,4 @@
 |---|---|---|---|
 | 2026-08-10 | Captcha on anonymous sign-in — Supabase flags unprotected anonymous auth as an abuse/MAU-cost risk. Not in spec; not built. | Auth (Slice 1) | pending |
 | 2026-08-10 | Orphaned households — removing every member leaves the `households` row, invisible to all via RLS and unreachable forever. No v1 flow deletes users, so not a Slice 1 defect. | Data model | pending |
+| 2026-08-10 | Item quantities ("2× milk") — `list_items` has no quantity field and the CRD never asks for one, but real lists carry them. Raised at Slice 2 Step 2 and deliberately left out of that slice. | Data model (Slice 2) | pending |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,14 +5,17 @@
 
 ## Last active
 
-- Ticket / spec section: 03-SPEC.md § Slice 1, filed as issue #1. **Closed.**
-- Status: Slices 0 and 1 are done, merged to `main`, and live at
-  https://cartel-kappa.vercel.app. Anonymous session persists across restarts,
-  household creation and invite-code pairing work end to end, palette is locked.
-  Verified across two independent browser sessions — never on a device.
-- Next step: **Slice 2 (#2, Lists & Items)**, starting at Protocol Step 2. Its
-  label says "no open questions"; that was also claimed for #1 and there were four.
-  Interrogate it before planning.
+- Ticket / spec section: 03-SPEC.md § Slice 2, filed as issue #2. **Deployed,
+  awaiting acceptance** — not merged to `main`.
+- Status: branch `slice-2-lists-items` (six commits, pushed) builds clean and is
+  live at the preview URL below. All ten of issue #2's checklist items verified
+  live, across two genuinely independent anonymous sessions (see the Traps entry
+  on browser tabs below — the first attempt at this used two tabs and proved
+  nothing). Native never run, as always.
+  https://cartel-git-slice-2-lists-items-mp3anthonys-projects.vercel.app
+- Next step: **your review of the preview**, then a decision on merging to `main`.
+  After that, **Slice 3 (#3, Real-Time Household Sync)** starts at Protocol Step 2.
+  Expect its "no open questions" label to be wrong too — check first.
 
 ## Notes for next session
 
@@ -20,49 +23,94 @@
 - Supabase project `cartel`, ref `chacavfoewyiwrfgvxtj`, ap-southeast-2, free tier.
   Free-tier projects pause after ~7 days idle; the first call back times out until
   it is woken from the dashboard. Anonymous sign-ins are enabled.
-- Vercel project `cartel` (mp3anthony's projects, Hobby) builds from `main`, Root
-  Directory `mobile`, build/output from `mobile/vercel.json`. Both `EXPO_PUBLIC_*`
-  env vars are set for Production and Preview. Expo bakes env values in at build
-  time, so a changed variable needs a redeploy, not just a save.
+- Vercel project `cartel` (mp3anthony's projects, Hobby) builds from `main` for
+  production and from any pushed branch for a preview. Root Directory `mobile`,
+  build/output from `mobile/vercel.json`. Preview deployments sit behind Vercel's
+  own auth — use the Vercel MCP's `get_access_to_vercel_url` for a 23-hour
+  shareable link rather than assuming a bare preview URL loads.
 - Repo was recreated fresh; old sync-engine history was deliberately left behind.
-  Local branch `main` still holds that abandoned history — `origin/main` is the real
-  one. Anyone checking out `main` locally gets the wrong repo. Worth deleting.
+  Local branch `main` still holds that abandoned history — `origin/main` is the
+  real one. Anyone checking out `main` locally gets the wrong repo. Worth deleting.
 
 **Decisions that will look like mistakes if you don't know why**
-- **No navigation library.** A deliberate client call, taken knowing the cost lands
-  in Slice 2. Screens are chosen from state in `App.tsx`. Slice 2 is the moment to
-  revisit it — do not silently extend the conditional rendering as if it were a
-  pattern.
-- **Writes go through security-definer RPCs, reads go through RLS.** Keep the split.
-  It is what makes invariants like "one household per user" and "one redemption per
-  code" atomic and checkable in one place instead of scattered through client code.
-- **No RLS policy tests for merely being signed in.** Anonymous users carry the
-  `authenticated` role, so "allow authenticated" means "allow everyone" — the exact
-  failure 03-SPEC.md § 0 calls a hard invariant violation. Policies test membership.
-- **Glanceability applies to Shopping Mode alone**, not the whole app. Intentional
-  split, don't "fix" it.
-- The accessibility baseline in 02-DESIGN-REFERENCE.md was written by the
-  orchestrator, not asked for by the client. Sensible default, not a requirement.
+- **React Navigation, adopted as its own commit ahead of Slice 2's feature work.**
+  Lists is the home screen for everyone now, household-or-not — Slice 1's "the
+  household screen is the whole app until you pair" could not survive Slice 2's own
+  acceptance test. The household is a route reached from the header, registered as
+  one screen or the other but never both, so the type system rules out landing on
+  a household screen with no household to show.
+- **`lists`/`list_items` are written direct-to-table under RLS**, not through
+  RPCs — a deliberate departure from Slice 1's rule. That rule exists for
+  invariants RLS can't express atomically; Slice 2 has none except promotion,
+  which kept its RPC. Don't silently extend the direct-write pattern to a future
+  slice that *does* have an atomicity invariant — re-derive it, don't copy it.
+- **No demotion function, and none should get added.** The want behind "make this
+  personal again" is *copy*, which is Slice 9's job. Enforced by a withheld
+  column-level UPDATE grant on `household_id`, not a trigger — grep for a trigger
+  here and you'll find nothing and wrongly conclude it's unenforced.
+- **`position` is `collate "C"`, and `fractional-indexing`'s `digits` argument is
+  never passed, anywhere.** Both are measured, not stylistic: this database sorts
+  `'a1' < 'A1'` under its default ICU collation, byte order says the opposite, and
+  base-62 keys only sort correctly under byte order. Separately, the package's
+  *value* digits default to base 62 but its *integer-head* alphabet defaults to
+  base 52 only when `digits` is omitted — passing it explicitly to "be consistent"
+  produces an incompatible keyspace and corrupts existing ordering against new
+  keys. `03-SPEC.md` § Slice 2 has the full mechanism.
+- `renameList`/`removeList` exist in `mobile/src/lib/lists.ts` and are **not**
+  wired to any screen — issue #2's checklist never needed list-level rename/delete,
+  so no UI was built for it. Known dead code, not an oversight.
 
 **Traps**
 - RLS policy expressions run as the *querying* user. Revoking a policy-helper
   function's EXECUTE from `authenticated` silently breaks every read while writes
-  keep working — creating a row succeeds and reading it back throws. Cost an hour;
-  see migration `20260810000002`.
-- Android and iOS have **never been run**, and that is recorded on #10 and #1 rather
-  than implied to pass. The Vercel link is the agreed review surface for the client
-  and their testers; Expo Go was considered and rejected as day-to-day workflow.
-  Treat native-only breakage as expected-but-undiscovered, not a regression.
+  keep working — creating a row succeeds and reading it back throws. Cost an hour
+  in Slice 1; see migration `20260810000002` (whose own header comment pointed at
+  the wrong file until this slice fixed it — the revoke is in `20260810000000`).
+- **A soft-delete policy must never reference `deleted_at`.** Realtime authorises
+  each event against the subscriber's SELECT policy evaluated on the *new* row, so
+  a policy saying `deleted_at is null` would suppress the very UPDATE that performs
+  the deletion — other members would never see a removal. Filtering `deleted_at` is
+  the client query's job, always. Getting this backwards is invisible until Slice 3
+  actually has two live subscribers.
+- **Two tabs of one browser profile are the same user.** `localStorage` is shared
+  per-origin, not per-tab — the anonymous session lives there, so two tabs prove
+  nothing about cross-household visibility. Confirmed by accident this session:
+  clearing one pane tab's storage to force a second identity silently clobbered the
+  *other* tab's session too, because they were never independent. Genuine
+  two-session verification needs two separate browser profiles (this session used
+  the in-app Browser pane for one and Claude-in-Chrome for the other), confirmed by
+  checking the two sessions' `auth.uid()`s actually differ before trusting the test.
+- `react-native-web` 0.21 does not map `accessibilityState.checked` (or `.busy`) to
+  the DOM's `aria-checked`/`aria-busy`. `CheckTarget` in `ui.tsx` carries both an
+  explicit `aria-checked` prop and `accessibilityState` for this reason — without
+  it the control announced `role="checkbox"` with no state at all, worse than no
+  role. `PrimaryButton` has the equivalent gap for `aria-busy`, not yet fixed — a
+  task chip was filed for it.
+- Android and iOS have **never been run**, and that is recorded on #10 and #1
+  rather than implied to pass. The Vercel link is the agreed review surface for
+  the client and their testers; Expo Go was considered and rejected as day-to-day
+  workflow. Treat native-only breakage as expected-but-undiscovered, not a
+  regression.
 - Test users are anonymous rows in `auth.users` with `is_anonymous = true`. Reset
   between runs with
   `delete from public.households; delete from auth.users where is_anonymous = true;`
+  — this now also cascades `public.lists` and `public.list_items`.
+- There is still no test harness beyond `supabase/tests/rls_lists.sql` (SQL-level
+  RLS assertions only, run via the Supabase MCP's `execute_sql` against the hosted
+  project — there is no local CLI, no `config.toml`, no Docker). That tool commits
+  each call in its own transaction regardless of an open `begin`, so state never
+  survives between separate `execute_sql` calls; a multi-statement script in one
+  call is fine, chaining state across calls is not.
 
 **Loose ends**
 - Palette is locked (burnt orange `#C2410C`) with measured contrast ratios in
-  `mobile/src/theme/tokens.ts` — that file is the source of truth, not the design doc.
+  `mobile/src/theme/tokens.ts` — that file is the source of truth, not the design
+  doc.
 - #4 (location merge UX) and #7 (route-learning heuristic) were labelled
   ready-for-human because the design reference was missing. That block is lifted —
   re-check whether they can move to ready-for-agent.
-- `CHANGE-LOG.md` has two pending items neither of which is built: captcha on
-  anonymous sign-in, and orphaned households after member removal.
+- `CHANGE-LOG.md` has three pending items, none built: captcha on anonymous
+  sign-in, orphaned households after member removal, and item quantities
+  (raised at Slice 2 Step 2, deliberately left out of that slice).
+- `PrimaryButton`'s missing `aria-busy` (see Traps) has an open task chip.
 - CLAUDE.md's "## Rules" section still has placeholder bullets.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,15 +5,18 @@
 
 ## Last active
 
-- Ticket / spec section: 03-SPEC.md § Slice 2, filed as issue #2. **Deployed,
-  awaiting acceptance** — not merged to `main`.
-- Status: branch `slice-2-lists-items` (six commits, pushed) builds clean and is
-  live at the preview URL below. All ten of issue #2's checklist items verified
-  live, across two genuinely independent anonymous sessions (see the Traps entry
-  on browser tabs below — the first attempt at this used two tabs and proved
-  nothing). Native never run, as always.
+- Ticket / spec section: 03-SPEC.md § Slice 2, filed as issue #2. **PR open,
+  awaiting your merge** — not yet merged to `main`.
+  https://github.com/mp3anthony/cartel/pull/12
+- Status: branch `slice-2-lists-items` (six commits, pushed) builds clean — the
+  exact Vercel build command (`npx expo export --platform web`) was re-run
+  against the branch tip before opening the PR — and is live at the preview URL
+  below. All ten of issue #2's checklist items verified live, across two
+  genuinely independent anonymous sessions (see the Traps entry on browser tabs
+  below — the first attempt at this used two tabs and proved nothing). Native
+  never run, as always.
   https://cartel-git-slice-2-lists-items-mp3anthonys-projects.vercel.app
-- Next step: **your review of the preview**, then a decision on merging to `main`.
+- Next step: **you merge PR #12 on GitHub** once you're happy with the PR view.
   After that, **Slice 3 (#3, Real-Time Household Sync)** starts at Protocol Step 2.
   Expect its "no open questions" label to be wrong too — check first.
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,6 +1,12 @@
 import { useMemo } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
+import {
+  NavigationContainer,
+  type LinkingOptions,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { Body, ErrorNote, Heading, Screen } from './src/components/ui';
 import { useAnonymousSession } from './src/hooks/useAnonymousSession';
@@ -10,37 +16,78 @@ import { getSupabaseClient } from './src/lib/supabase';
 import { ConfigErrorScreen } from './src/screens/ConfigErrorScreen';
 import { HouseholdScreen } from './src/screens/HouseholdScreen';
 import { HouseholdSetupScreen } from './src/screens/HouseholdSetupScreen';
-import { ThemeProvider } from './src/theme/ThemeProvider';
-import { useTheme } from './src/theme/ThemeProvider';
+import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
+import type { Tokens } from './src/theme/tokens';
+
+/**
+ * Every route's parameters, in one place. React Navigation cannot check a route
+ * parameter it has not been told about, and a deep link is the one caller that can
+ * arrive with any shape at all — an untyped param is `undefined` at runtime the
+ * first time someone opens a hand-edited URL.
+ */
+export type RootStackParamList = {
+  HouseholdSetup: undefined;
+  Household: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+/**
+ * What gives each screen a URL. Without it React Navigation never touches browser
+ * history, and the Vercel build — the agreed review surface — answers Back by
+ * leaving the app. The web origin is implicit, so only the native scheme (declared
+ * in `app.json`) needs listing here.
+ */
+const linking: LinkingOptions<RootStackParamList> = {
+  prefixes: ['cartel://'],
+  config: {
+    screens: {
+      HouseholdSetup: 'household/setup',
+      Household: 'household',
+    },
+  },
+};
 
 export default function App() {
   return (
     <ThemeProvider>
-      {envResult.ok ? (
-        <Bootstrapped env={envResult.env} />
-      ) : (
-        <ConfigErrorScreen
-          problem={envResult.problem}
-          remedy={envResult.remedy}
-        />
-      )}
-      <StatusBar style="dark" />
+      {/* Insets read as zero without this provider, so the whole tree sits inside
+          it — including the branches that never reach the navigator. */}
+      <SafeAreaProvider>
+        {envResult.ok ? (
+          <Bootstrapped env={envResult.env} />
+        ) : (
+          <ConfigErrorScreen
+            problem={envResult.problem}
+            remedy={envResult.remedy}
+          />
+        )}
+        <StatusBar style="dark" />
+      </SafeAreaProvider>
     </ThemeProvider>
   );
 }
 
 /**
- * Chooses the screen from state rather than routing to it. Slice 1 has four screens
- * and no navigation library by decision, so "which screen" is a question about the
- * data, not about history: you are booting, or signed out, or in a household, or
- * not. None of those are places you navigate back to.
+ * The boot states stay branches and only the destinations become routes.
  *
- * This stops paying for itself once screens outnumber states, which is Slice 2.
+ * Booting, failing to get a session and failing to load the household are not places
+ * — you cannot navigate back to them and they have no URL worth writing down — so
+ * putting them in the navigator would buy history entries nobody wants. Everything
+ * past them is a place, which is why the household branch registers screens instead
+ * of returning them: from Slice 2 on, back and the browser URL have to mean
+ * something, and that is the whole reason the navigator was adopted.
+ *
+ * Which screens are registered still depends on the data. Registering both and
+ * navigating between them would let a user land on the household screen without a
+ * household, and the type would not stop them.
  */
 function Bootstrapped({ env }: { env: Env }) {
   const client = useMemo(() => getSupabaseClient(env), [env]);
   const session = useAnonymousSession(client);
   const { view, refresh } = useHousehold(client, session.status === 'ready');
+  const tokens = useTheme();
+  const screenOptions = useMemo(() => headerOptions(tokens), [tokens]);
 
   if (session.status === 'error') {
     return (
@@ -65,18 +112,43 @@ function Bootstrapped({ env }: { env: Env }) {
     );
   }
 
-  if (view.state.status === 'none') {
-    return <HouseholdSetupScreen client={client} onJoined={refresh} />;
-  }
+  const state = view.state;
 
   return (
-    <HouseholdScreen
-      client={client}
-      household={view.state.household}
-      memberCount={view.state.memberCount}
-      onRefresh={refresh}
-    />
+    <NavigationContainer linking={linking} fallback={<Loading />}>
+      <Stack.Navigator screenOptions={screenOptions}>
+        {state.status === 'none' ? (
+          <Stack.Screen name="HouseholdSetup" options={{ title: 'Cartel' }}>
+            {() => <HouseholdSetupScreen client={client} onJoined={refresh} />}
+          </Stack.Screen>
+        ) : (
+          <Stack.Screen name="Household" options={{ title: state.household.name }}>
+            {() => (
+              <HouseholdScreen
+                client={client}
+                memberCount={state.memberCount}
+                onRefresh={refresh}
+              />
+            )}
+          </Stack.Screen>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
   );
+}
+
+/**
+ * The header is the one surface the navigator draws itself, so it is also the one
+ * place tokens have to be handed over rather than read.
+ */
+function headerOptions(tokens: Tokens) {
+  return {
+    headerStyle: { backgroundColor: tokens.color.ground },
+    headerTintColor: tokens.color.textPrimary,
+    headerTitleStyle: { fontWeight: '600' as const },
+    headerShadowVisible: false,
+    contentStyle: { backgroundColor: tokens.color.ground },
+  };
 }
 
 function Loading() {

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -11,24 +11,17 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Body, ErrorNote, Heading, Screen } from './src/components/ui';
 import { useAnonymousSession } from './src/hooks/useAnonymousSession';
 import { useHousehold } from './src/hooks/useHousehold';
+import { useLists } from './src/hooks/useLists';
 import { envResult, type Env } from './src/lib/env';
 import { getSupabaseClient } from './src/lib/supabase';
+import type { RootStackParamList } from './src/navigation/types';
 import { ConfigErrorScreen } from './src/screens/ConfigErrorScreen';
 import { HouseholdScreen } from './src/screens/HouseholdScreen';
 import { HouseholdSetupScreen } from './src/screens/HouseholdSetupScreen';
+import { ListDetailScreen } from './src/screens/ListDetailScreen';
+import { ListsScreen } from './src/screens/ListsScreen';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import type { Tokens } from './src/theme/tokens';
-
-/**
- * Every route's parameters, in one place. React Navigation cannot check a route
- * parameter it has not been told about, and a deep link is the one caller that can
- * arrive with any shape at all — an untyped param is `undefined` at runtime the
- * first time someone opens a hand-edited URL.
- */
-export type RootStackParamList = {
-  HouseholdSetup: undefined;
-  Household: undefined;
-};
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -37,11 +30,24 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
  * history, and the Vercel build — the agreed review surface — answers Back by
  * leaving the app. The web origin is implicit, so only the native scheme (declared
  * in `app.json`) needs listing here.
+ *
+ * `Lists` takes the empty path because it is the home screen for every user, with or
+ * without a household.
+ *
+ * `initialRouteName` is what puts `Lists` underneath a deep-linked screen rather than
+ * replacing it. Without it, opening `/list/<id>` cold builds a stack one screen deep:
+ * the header draws no back button and browser Back leaves the app — the exact failure
+ * the navigator was adopted to fix, reintroduced through the door deep links use. The
+ * navigator's own `initialRouteName` does not cover this; a state rehydrated from a
+ * URL is used as given.
  */
 const linking: LinkingOptions<RootStackParamList> = {
   prefixes: ['cartel://'],
   config: {
+    initialRouteName: 'Lists',
     screens: {
+      Lists: '',
+      ListDetail: 'list/:listId',
       HouseholdSetup: 'household/setup',
       Household: 'household',
     },
@@ -78,14 +84,27 @@ export default function App() {
  * of returning them: from Slice 2 on, back and the browser URL have to mean
  * something, and that is the whole reason the navigator was adopted.
  *
- * Which screens are registered still depends on the data. Registering both and
- * navigating between them would let a user land on the household screen without a
- * household, and the type would not stop them.
+ * `Lists` is home for every user. Slice 1 made the household screens the whole app
+ * for anyone without a household, and Slice 2 cannot keep that: a user who has never
+ * created or joined one still builds lists, so the household became a place you go
+ * rather than the door you come in through.
+ *
+ * Which of the two household screens is registered still depends on the data. It is
+ * one or the other, never both — registering both and navigating between them would
+ * let a user land on the household screen without a household, and the type would
+ * not stop them.
+ *
+ * The list index is loaded here rather than inside the screen that shows it, because
+ * the detail screen reads its own list's name and scope out of the same array. One
+ * copy means promoting a list on the detail screen changes the badge on the index
+ * too, without either screen knowing the other exists.
  */
 function Bootstrapped({ env }: { env: Env }) {
   const client = useMemo(() => getSupabaseClient(env), [env]);
   const session = useAnonymousSession(client);
-  const { view, refresh } = useHousehold(client, session.status === 'ready');
+  const ready = session.status === 'ready';
+  const { view, refresh } = useHousehold(client, ready);
+  const lists = useLists(client, ready);
   const tokens = useTheme();
   const screenOptions = useMemo(() => headerOptions(tokens), [tokens]);
 
@@ -116,9 +135,35 @@ function Bootstrapped({ env }: { env: Env }) {
 
   return (
     <NavigationContainer linking={linking} fallback={<Loading />}>
-      <Stack.Navigator screenOptions={screenOptions}>
+      <Stack.Navigator initialRouteName="Lists" screenOptions={screenOptions}>
+        <Stack.Screen name="Lists" options={{ title: 'Cartel' }}>
+          {(props) => (
+            <ListsScreen
+              {...props}
+              client={client}
+              view={lists.view}
+              refresh={lists.refresh}
+              household={state.status === 'member' ? state.household : null}
+            />
+          )}
+        </Stack.Screen>
+
+        {/* The title is a placeholder: the screen replaces it with the list's name
+            once the index resolves, which on a cold deep link is a moment later. */}
+        <Stack.Screen name="ListDetail" options={{ title: 'List' }}>
+          {(props) => (
+            <ListDetailScreen
+              {...props}
+              client={client}
+              lists={lists.view}
+              onListsChanged={lists.refresh}
+              inHousehold={state.status === 'member'}
+            />
+          )}
+        </Stack.Screen>
+
         {state.status === 'none' ? (
-          <Stack.Screen name="HouseholdSetup" options={{ title: 'Cartel' }}>
+          <Stack.Screen name="HouseholdSetup" options={{ title: 'Household' }}>
             {() => <HouseholdSetupScreen client={client} onJoined={refresh} />}
           </Stack.Screen>
         ) : (

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.112.2",
         "expo": "~57.0.11",
         "expo-status-bar": "~57.0.1",
+        "fractional-indexing": "^4.0.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.86.2",
@@ -3550,6 +3551,15 @@
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
       "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/fractional-indexing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-4.0.0.tgz",
+      "integrity": "sha512-Nr2P1Yyaj2sy1Qdt/wI3GcByxrUdbSKg5+cGvw8f18hT2SkQt6V72iOjBpk7IO3UkzBsdlGRs2a4z6dLrJprgw==",
+      "license": "CC0-1.0",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/fresh": {
       "version": "0.5.2",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,12 +10,16 @@
       "dependencies": {
         "@expo/metro-runtime": "~57.0.8",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-navigation/native": "^7.3.16",
+        "@react-navigation/native-stack": "^7.18.8",
         "@supabase/supabase-js": "^2.112.2",
         "expo": "~57.0.11",
         "expo-status-bar": "~57.0.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.86.2",
+        "react-native-safe-area-context": "~5.7.0",
+        "react-native-screens": "~4.26.0",
         "react-native-url-polyfill": "^4.0.0",
         "react-native-web": "^0.21.2"
       },
@@ -1742,6 +1746,100 @@
         }
       }
     },
+    "node_modules/@react-navigation/core": {
+      "version": "7.21.12",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.21.12.tgz",
+      "integrity": "sha512-FopGMGy5df+IMqUYg9w7ygwK0oP4RaQbMnpb7VFP30+vZdd8MqsAGc+bZZwdiVSnzK9hzhgJtZV9XF0ZFlUYOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/routers": "^7.6.4",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "query-string": "^7.1.3",
+        "react-is": "^19.1.0",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-navigation/elements": {
+      "version": "2.9.38",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.38.tgz",
+      "integrity": "sha512-M/2HWDiSO4zO7VyfAnovrTPWOAzTC+1DnVT7ZWZW93+/KVRF9OYlqixIUpPenQ0iQh2j1EaQ4zOe/134Arisqw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@react-native-masked-view/masked-view": ">= 0.2.0",
+        "@react-navigation/native": "^7.3.16",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-masked-view/masked-view": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "7.3.16",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.3.16.tgz",
+      "integrity": "sha512-Wy/6mai2HpA5AEVFk7JFfvv4RUArwuN2UenP/fc3NK7kOyfSlNu1tmb/3JDPpMzPIRbF1MPB8PKAHjVB29qNEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^7.21.12",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "standard-navigation": "^0.0.8",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.18.8.tgz",
+      "integrity": "sha512-Abcdt2ndmbeNSzJCXggxduK7X9yvMIajPNPdHgxsAZaA+16aIhb7TXZ2kRXprStZX5TRg8x+8G07Ne3kFwIQDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.38",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.3.16",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
+    "node_modules/@react-navigation/routers": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.6.4.tgz",
+      "integrity": "sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.12",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
@@ -2426,6 +2524,19 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2443,6 +2554,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -2613,6 +2734,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/deepmerge": {
@@ -3292,6 +3422,12 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -3359,6 +3495,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -3638,6 +3783,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
@@ -5191,6 +5342,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -5238,6 +5407,18 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
       }
     },
     "node_modules/react-is": {
@@ -5303,6 +5484,30 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
+      "integrity": "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
+      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
+      "license": "MIT",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-url-polyfill": {
@@ -5642,6 +5847,15 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sf-symbols-typescript": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sf-symbols-typescript/-/sf-symbols-typescript-2.2.0.tgz",
+      "integrity": "sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5690,6 +5904,15 @@
         "bplist-creator": "0.1.0",
         "bplist-parser": "0.3.1",
         "plist": "^3.0.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/sisteransi": {
@@ -5744,6 +5967,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -5762,6 +5994,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/standard-navigation": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/standard-navigation/-/standard-navigation-0.0.8.tgz",
+      "integrity": "sha512-TyVbo7INUDWtsUWDFn8RR7kwR87U0S4xHfLfbbnyeC581TmmyqQ+eM+nPw8rQTSD8QitRVcYfPaSHr/QJiUy1g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -5778,6 +6019,15 @@
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string-width": {
@@ -6125,6 +6375,24 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -6176,6 +6444,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -5,12 +5,16 @@
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-navigation/native": "^7.3.16",
+    "@react-navigation/native-stack": "^7.18.8",
     "@supabase/supabase-js": "^2.112.2",
     "expo": "~57.0.11",
     "expo-status-bar": "~57.0.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.2",
+    "react-native-safe-area-context": "~5.7.0",
+    "react-native-screens": "~4.26.0",
     "react-native-url-polyfill": "^4.0.0",
     "react-native-web": "^0.21.2"
   },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "@supabase/supabase-js": "^2.112.2",
     "expo": "~57.0.11",
     "expo-status-bar": "~57.0.1",
+    "fractional-indexing": "^4.0.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.2",

--- a/mobile/src/components/ui.tsx
+++ b/mobile/src/components/ui.tsx
@@ -2,6 +2,7 @@ import { useMemo, type ReactNode } from 'react';
 import {
   ActivityIndicator,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -25,20 +26,58 @@ import type { Tokens } from '../theme/tokens';
  * react-native core one. They are not interchangeable: core pads on iOS only, the
  * context version reports real insets everywhere. Mixing them means one of the two
  * is wrong on every platform.
+ *
+ * `align` and `scroll` both default to the shape every Slice 1 screen already has —
+ * a short, vertically centred column that does not scroll. That shape cannot back a
+ * list, so lists opt in; nothing else changes.
+ *
+ * `scroll` uses a ScrollView and deliberately not a FlatList. A grocery list is tens
+ * of rows, so virtualisation buys nothing measurable, and a FlatList inside a
+ * flex-centred container is the classic way to get a zero-height list or a
+ * nested-virtualisation warning — real costs paid for an imaginary benefit.
+ *
+ * `maxWidth` applies in both modes. Without it the web build — the agreed review
+ * surface — renders list rows the full width of a desktop window.
  */
 export function Screen({
   children,
   edges = ['top', 'bottom', 'left', 'right'],
+  align = 'center',
+  scroll = false,
 }: {
   children: ReactNode;
   edges?: readonly Edge[];
+  align?: 'center' | 'top';
+  scroll?: boolean;
 }) {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const centred = align === 'center';
+
+  if (scroll) {
+    return (
+      <SafeAreaView edges={edges} style={styles.ground}>
+        <ScrollView
+          style={styles.scrollFrame}
+          contentContainerStyle={[
+            styles.scrollContent,
+            centred && styles.scrollContentCentred,
+          ]}
+          // A list screen carries a text field and buttons at once. Without this, the
+          // first tap on a button only dismisses the keyboard and the press is lost.
+          keyboardShouldPersistTaps="handled"
+        >
+          {children}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView edges={edges} style={styles.ground}>
-      <View style={styles.content}>{children}</View>
+      <View style={[styles.content, !centred && styles.contentTop]}>
+        {children}
+      </View>
     </SafeAreaView>
   );
 }
@@ -169,6 +208,246 @@ export function ErrorNote({ message }: { message: string }) {
   );
 }
 
+/**
+ * One line of a list: an optional leading element, a label, an optional trailing one.
+ *
+ * `leading` is a generic slot rather than the coloured section chip the design
+ * reference describes, because that chip needs store sections and those arrive in
+ * Slice 6. A slot now costs nothing; a chip now would be a component with no data.
+ *
+ * `onPress` is optional and the row is a plain View without it. A row whose only
+ * actions live in its trailing controls is not itself a button, and announcing it as
+ * one gives a screen reader a control that does nothing.
+ */
+export function Row({
+  label,
+  leading,
+  trailing,
+  onPress,
+}: {
+  label: string;
+  leading?: ReactNode;
+  trailing?: ReactNode;
+  onPress?: () => void;
+}) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const contents = (
+    <>
+      {leading}
+      <Text numberOfLines={1} style={styles.rowLabel}>
+        {label}
+      </Text>
+      {trailing}
+    </>
+  );
+
+  if (!onPress) {
+    return <View style={styles.row}>{contents}</View>;
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+    >
+      {contents}
+    </Pressable>
+  );
+}
+
+/**
+ * The circular check control from the design reference's list-row anatomy.
+ *
+ * Checked is signalled by a glyph *and* the accent fill, never the fill alone — the
+ * same rule ErrorNote follows, and the one the design reference states outright.
+ * Colour-only state is invisible to anyone who cannot separate these two hues.
+ *
+ * The drawn circle is smaller than the target it sits in. Inflating the circle to
+ * 44pt to make it tappable would put a control the size of the row's text next to
+ * that text; padding the touchable instead keeps the 44pt floor without the weight.
+ *
+ * `accessibilityLabel` is required because the visible content is a glyph. In a Row
+ * the neighbouring label reads as the name to a sighted user, but nothing in the
+ * accessibility tree connects the two, so the control has to name itself.
+ */
+export function CheckTarget({
+  checked,
+  onToggle,
+  accessibilityLabel,
+  disabled = false,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  accessibilityLabel: string;
+  disabled?: boolean;
+}) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  return (
+    <Pressable
+      accessibilityRole="checkbox"
+      accessibilityLabel={accessibilityLabel}
+      // Both spellings of the same fact, and both are needed. `accessibilityState` is
+      // what the native platforms read; react-native-web 0.21 ignores it for `checked`
+      // and emits `aria-checked` only from the `aria-checked` prop — measured on the
+      // web build, where the checkbox otherwise announced with no state whatsoever.
+      // A role of "checkbox" with no checked state is worse than no role at all.
+      aria-checked={checked}
+      accessibilityState={{ checked, disabled }}
+      disabled={disabled}
+      onPress={onToggle}
+      style={({ pressed }) => [
+        styles.touchTarget,
+        pressed && styles.touchTargetPressed,
+        disabled && styles.buttonInactive,
+      ]}
+    >
+      <View style={[styles.checkCircle, checked && styles.checkCircleChecked]}>
+        {checked ? <Text style={styles.checkGlyph}>✓</Text> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+/**
+ * A button whose whole face is one text glyph.
+ *
+ * `accessibilityLabel` is required rather than optional: a glyph carries no name, so
+ * an unlabelled one is announced as its own character or as nothing at all. Making
+ * the type demand it is the only version of that rule that cannot be forgotten.
+ *
+ * `disabled` exists so the ends of a list can refuse a move without the control
+ * disappearing. Hiding it instead would shift every other control in the row the
+ * moment an item reaches the top or bottom, which is a moving target to tap.
+ */
+export function IconButton({
+  glyph,
+  accessibilityLabel,
+  onPress,
+  disabled = false,
+}: {
+  glyph: string;
+  accessibilityLabel: string;
+  onPress: () => void;
+  disabled?: boolean;
+}) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.touchTarget,
+        pressed && styles.touchTargetPressed,
+        disabled && styles.buttonInactive,
+      ]}
+    >
+      <Text style={styles.iconGlyph}>{glyph}</Text>
+    </Pressable>
+  );
+}
+
+/**
+ * What a list shows before it has anything in it.
+ *
+ * The action is typed as a pair: either both `actionLabel` and `onAction` or neither.
+ * A label with no handler is a button that does nothing, and a handler with no label
+ * is a button nobody can see — both are compile-time avoidable.
+ */
+export function EmptyState({
+  heading,
+  body,
+  ...action
+}: {
+  heading: string;
+  body: string;
+} & (
+  | { actionLabel: string; onAction: () => void }
+  | { actionLabel?: undefined; onAction?: undefined }
+)) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  return (
+    <View style={styles.emptyState}>
+      <Heading>{heading}</Heading>
+      <Body>{body}</Body>
+      {action.actionLabel ? (
+        <PrimaryButton label={action.actionLabel} onPress={action.onAction} />
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * An in-place confirmation, rendered as part of the screen rather than over it.
+ *
+ * Not `Alert.alert`, and this is not a style preference: react-native-web does not
+ * implement `Alert`, so on the Vercel build — the only surface this project has ever
+ * verified anything on — the call is a silent no-op. A confirmation that silently
+ * does not appear is worse than none, because the code reads as if it asked.
+ *
+ * The confirm action reuses PrimaryButton. Cartel has one accent and therefore one
+ * primary action; while this card is on screen, this is it.
+ */
+export function Confirm({
+  message,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  busy = false,
+}: {
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  busy?: boolean;
+}) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  return (
+    <View accessibilityRole="alert">
+      <Card>
+        <Body>{message}</Body>
+        <View style={styles.confirmActions}>
+          <PrimaryButton label={confirmLabel} onPress={onConfirm} busy={busy} />
+          {/* Fixed copy, unlike every other label in this file. "Cancel" is the one
+              word a reader never has to read twice, and a configurable version only
+              invites each caller to invent its own way of saying nothing happened. */}
+          <SecondaryButton label="Cancel" onPress={onCancel} disabled={busy} />
+        </View>
+      </Card>
+    </View>
+  );
+}
+
+/**
+ * A small scope marker. The wash is decoration and the text is the information —
+ * `accentWash` is too pale to carry meaning on its own, which is what its own token
+ * comment says, so the label is ordinary primary text that happens to sit on it.
+ */
+export function Badge({ label }: { label: string }) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  return (
+    <View style={styles.badge}>
+      <Text style={styles.badgeLabel}>{label}</Text>
+    </View>
+  );
+}
+
 function createStyles(tokens: Tokens) {
   return StyleSheet.create({
     ground: {
@@ -183,6 +462,29 @@ function createStyles(tokens: Tokens) {
       maxWidth: 480,
       width: '100%',
       alignSelf: 'center',
+    },
+    contentTop: {
+      justifyContent: 'flex-start',
+    },
+    // The width cap belongs to the scroller, not its contents: put it on the content
+    // container instead and the scrollbar ends up 480pt from the edge of the window.
+    scrollFrame: {
+      flex: 1,
+      width: '100%',
+      maxWidth: 480,
+      alignSelf: 'center',
+    },
+    scrollContent: {
+      flexGrow: 1,
+      paddingHorizontal: tokens.space.lg,
+      // Vertical padding matches the gap, so the first and last rows sit the same
+      // distance from the edges as they do from each other. The non-scrolling layout
+      // needs none of this: centring keeps its content off both edges for free.
+      paddingVertical: tokens.space.md,
+      gap: tokens.space.md,
+    },
+    scrollContentCentred: {
+      justifyContent: 'center',
     },
     heading: {
       fontSize: tokens.fontSize.display,
@@ -271,6 +573,79 @@ function createStyles(tokens: Tokens) {
       color: tokens.color.negative,
       fontSize: tokens.fontSize.caption,
       lineHeight: tokens.fontSize.caption * 1.5,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: tokens.space.md,
+      minHeight: tokens.minTouchTarget,
+      paddingHorizontal: tokens.space.md,
+      paddingVertical: tokens.space.xs,
+      backgroundColor: tokens.color.surface,
+      borderRadius: tokens.radius.md,
+    },
+    rowPressed: {
+      backgroundColor: tokens.color.surfaceSunken,
+    },
+    rowLabel: {
+      flex: 1,
+      fontSize: tokens.fontSize.body,
+      color: tokens.color.textPrimary,
+    },
+    // Shared by every glyph-only control here. The box is the 44pt floor; what gets
+    // drawn inside it is the component's business and is always smaller.
+    touchTarget: {
+      width: tokens.minTouchTarget,
+      height: tokens.minTouchTarget,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: tokens.radius.pill,
+    },
+    touchTargetPressed: {
+      backgroundColor: tokens.color.surfaceSunken,
+    },
+    checkCircle: {
+      width: tokens.space.lg,
+      height: tokens.space.lg,
+      borderRadius: tokens.radius.pill,
+      borderWidth: 2,
+      borderColor: tokens.color.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    checkCircleChecked: {
+      backgroundColor: tokens.color.accent,
+      borderColor: tokens.color.accent,
+    },
+    checkGlyph: {
+      color: tokens.color.accentContrast,
+      fontSize: tokens.fontSize.caption,
+      fontWeight: '700',
+      lineHeight: tokens.fontSize.caption,
+    },
+    iconGlyph: {
+      color: tokens.color.textPrimary,
+      fontSize: tokens.fontSize.title,
+      lineHeight: tokens.fontSize.title,
+    },
+    emptyState: {
+      paddingVertical: tokens.space.xl,
+      gap: tokens.space.md,
+    },
+    confirmActions: {
+      gap: tokens.space.sm,
+    },
+    badge: {
+      alignSelf: 'flex-start',
+      backgroundColor: tokens.color.accentWash,
+      borderRadius: tokens.radius.pill,
+      paddingHorizontal: tokens.space.sm,
+      paddingVertical: tokens.space.xs,
+    },
+    badgeLabel: {
+      fontSize: tokens.fontSize.caption,
+      fontWeight: '600',
+      color: tokens.color.textPrimary,
     },
   });
 }

--- a/mobile/src/components/ui.tsx
+++ b/mobile/src/components/ui.tsx
@@ -2,13 +2,13 @@ import { useMemo, type ReactNode } from 'react';
 import {
   ActivityIndicator,
   Pressable,
-  SafeAreaView,
   StyleSheet,
   Text,
   TextInput,
   View,
   type TextInputProps,
 } from 'react-native';
+import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme/ThemeProvider';
 import type { Tokens } from '../theme/tokens';
@@ -16,17 +16,35 @@ import type { Tokens } from '../theme/tokens';
 /**
  * The shared surface every screen sits on. Centralising it is what keeps the ground
  * colour, the gutter and the safe-area handling from drifting screen by screen.
+ *
+ * `edges` exists because a screen inside the navigator already has a header holding
+ * the top inset, and insetting again pads twice. Screens outside the navigator take
+ * the default and inset on all four sides themselves.
+ *
+ * This SafeAreaView is the one from `react-native-safe-area-context`, never the
+ * react-native core one. They are not interchangeable: core pads on iOS only, the
+ * context version reports real insets everywhere. Mixing them means one of the two
+ * is wrong on every platform.
  */
-export function Screen({ children }: { children: ReactNode }) {
+export function Screen({
+  children,
+  edges = ['top', 'bottom', 'left', 'right'],
+}: {
+  children: ReactNode;
+  edges?: readonly Edge[];
+}) {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
   return (
-    <SafeAreaView style={styles.ground}>
+    <SafeAreaView edges={edges} style={styles.ground}>
       <View style={styles.content}>{children}</View>
     </SafeAreaView>
   );
 }
+
+/** For screens the navigator renders: its header has already taken the top inset. */
+export const NAVIGATOR_EDGES: readonly Edge[] = ['bottom', 'left', 'right'];
 
 export function Heading({ children }: { children: ReactNode }) {
   const tokens = useTheme();

--- a/mobile/src/hooks/useListItems.ts
+++ b/mobile/src/hooks/useListItems.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { loadItems, type ListItemRow } from '../lib/lists';
+
+export type ItemsView =
+  | { status: 'loading' }
+  | { status: 'loaded'; items: ListItemRow[] }
+  | { status: 'error'; message: string };
+
+/**
+ * One list's items, in the order `loadItems` returns them.
+ *
+ * That order is the one every reorder control computes against — `moveItem` takes the
+ * positions of the neighbours an item will land between, read from the list as
+ * rendered — so nothing downstream may re-sort these rows. Grouping checked items at
+ * the bottom is a render-time concern the spec allows, but it would put the rendered
+ * index and the ordering index out of step, and the move would then land back in the
+ * gap it came from without erroring.
+ *
+ * No `enabled` flag: this hook is only ever mounted by a screen the navigator renders,
+ * which is already past the session gate its parent holds.
+ */
+export function useListItems(client: SupabaseClient, listId: string) {
+  const [view, setView] = useState<ItemsView>({ status: 'loading' });
+  const active = useRef(true);
+
+  // Declared before the loading effect so its cleanup runs first on unmount.
+  useEffect(() => {
+    active.current = true;
+
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const outcome = await loadItems(client, listId);
+
+    if (!active.current) {
+      return;
+    }
+
+    setView(
+      outcome.ok
+        ? { status: 'loaded', items: outcome.value }
+        : { status: 'error', message: outcome.message },
+    );
+  }, [client, listId]);
+
+  useEffect(() => {
+    // `refresh` changes identity only when the list being viewed does, so this resets
+    // to loading exactly then and never on the manual refresh after a write — which
+    // would otherwise flash a spinner over the list on every check-off.
+    setView({ status: 'loading' });
+    refresh();
+  }, [refresh]);
+
+  return { view, refresh };
+}

--- a/mobile/src/hooks/useLists.ts
+++ b/mobile/src/hooks/useLists.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { loadLists, type ListRow } from '../lib/lists';
+
+export type ListsView =
+  | { status: 'loading' }
+  | { status: 'loaded'; lists: ListRow[] }
+  | { status: 'error'; message: string };
+
+/**
+ * The list index, loaded once and reloaded after every write.
+ *
+ * There are no optimistic updates here or anywhere in this slice: a mutation writes,
+ * then calls `refresh`. Guessing at the result would mean two sources of truth for
+ * the same rows, and Slice 3's live subscription is the point at which reconciling
+ * them becomes a coherent thing to design rather than a shortcut.
+ *
+ * Unlike `useHousehold` this one guards against landing on an unmounted screen.
+ * `refresh` is called after every add, rename, check, move and remove, so a response
+ * arriving after the user has navigated away is a matter of when, not whether.
+ */
+export function useLists(client: SupabaseClient, enabled: boolean) {
+  const [view, setView] = useState<ListsView>({ status: 'loading' });
+  const active = useRef(true);
+
+  // Declared before the loading effect so its cleanup runs first on unmount.
+  useEffect(() => {
+    active.current = true;
+
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const outcome = await loadLists(client);
+
+    if (!active.current) {
+      return;
+    }
+
+    setView(
+      outcome.ok
+        ? { status: 'loaded', lists: outcome.value }
+        : { status: 'error', message: outcome.message },
+    );
+  }, [client]);
+
+  useEffect(() => {
+    // Waits for the session for the same reason `useHousehold` does: RLS scopes this
+    // query by auth.uid(), so running it signed-out returns no lists rather than an
+    // error — indistinguishable from genuinely having none.
+    if (enabled) {
+      refresh();
+    }
+  }, [enabled, refresh]);
+
+  return { view, refresh };
+}

--- a/mobile/src/lib/household.ts
+++ b/mobile/src/lib/household.ts
@@ -33,13 +33,40 @@ const MESSAGES: Record<string, string> = {
   invalid_or_expired_code:
     "That code isn't valid. Codes are single-use and expire after 24 hours.",
   could_not_generate_code: 'Could not generate a code just now. Try again.',
+  list_not_found: 'That list no longer exists.',
+  not_list_owner: 'Only the person who made a list can share it.',
+  already_shared: 'That list is already shared with your household.',
 };
 
-function humanise(error: { message: string }): string {
+/**
+ * Lists and items are written direct to table under RLS rather than through an RPC, so
+ * their likeliest failure is not one of the named exceptions above. A `with check`
+ * violation and a withheld column privilege both arrive as raw Postgres prose — `new
+ * row violates row-level security policy for table "lists"`, `permission denied for
+ * column household_id` — under SQLSTATE 42501. Falling those through verbatim would
+ * hand a user the schema. They are predictable, so they get prose; the fallthrough
+ * below stays for the errors that genuinely are unfamiliar.
+ *
+ * Both the code and the text are checked because the code is the reliable signal when
+ * it is present and PostgREST does not always carry one (a network or gateway failure
+ * surfaces through the same error shape with no SQLSTATE at all).
+ */
+const DENIED = "You don't have access to that list.";
+
+const DENIAL_TEXT = [
+  'violates row-level security policy',
+  'permission denied for column',
+];
+
+export function humanise(error: { message: string; code?: string }): string {
   for (const [code, message] of Object.entries(MESSAGES)) {
     if (error.message.includes(code)) {
       return message;
     }
+  }
+
+  if (error.code === '42501' || DENIAL_TEXT.some((text) => error.message.includes(text))) {
+    return DENIED;
   }
 
   return error.message;

--- a/mobile/src/lib/lists.ts
+++ b/mobile/src/lib/lists.ts
@@ -1,0 +1,342 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { generateKeyBetween } from 'fractional-indexing';
+
+import { humanise, type Outcome } from './household';
+
+export type ListRow = {
+  id: string;
+  name: string;
+  householdId: string | null;
+  createdAt: string;
+};
+
+export type ListItemRow = {
+  id: string;
+  name: string;
+  position: string;
+  checkedAt: string | null;
+};
+
+/**
+ * The database's spelling of the two rows above, kept separate rather than exported so
+ * that snake_case stops at this file. Callers get camelCase and a column rename becomes
+ * a change to one mapping function instead of a change to every screen.
+ */
+type ListRecord = {
+  id: string;
+  name: string;
+  household_id: string | null;
+  created_at: string;
+};
+
+type ListItemRecord = {
+  id: string;
+  name: string;
+  position: string;
+  checked_at: string | null;
+};
+
+/**
+ * The only call into `fractional-indexing` anywhere in the app, for two reasons.
+ *
+ * It signals failure by throwing, not by returning — adjacent keys, a trailing zero, a
+ * pair passed in the wrong order — and an uncaught throw inside a screen handler is a
+ * white screen on the review surface rather than a message.
+ *
+ * And `digits` must never be passed. The default alphabet is the format every stored
+ * `position` is already written in; passing `digits` explicitly, even the very
+ * BASE_62_DIGITS the default is built from, changes the integer-head alphabet and
+ * yields keys that sort against the existing ones incorrectly. That is a stored-data
+ * format commitment, made once. One call site makes it something you can check rather
+ * than a rule spread across nine functions and trusted.
+ */
+function keyBetween(before: string | null, after: string | null): Outcome<string> {
+  try {
+    return { ok: true, value: generateKeyBetween(before, after) };
+  } catch {
+    return {
+      ok: false,
+      message: 'Could not work out where that goes. Reload the list and try again.',
+    };
+  }
+}
+
+export async function loadLists(client: SupabaseClient): Promise<Outcome<ListRow[]>> {
+  // RLS scopes this to lists the caller owns or shares with their household, so no
+  // filter on owner or household is added here — adding one would imply the query is
+  // trusted to do the scoping. It is not.
+  //
+  // `deleted_at` is the deliberate exception. No policy mentions it, because Realtime
+  // authorises each event against the SELECT policy evaluated on the *new* row, so a
+  // policy saying `deleted_at is null` would suppress the very UPDATE that performs the
+  // deletion. Filtering it here is the whole of the mechanism.
+  const { data, error } = await client
+    .from('lists')
+    .select('id, name, household_id, created_at')
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as ListRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      householdId: row.household_id,
+      createdAt: row.created_at,
+    })),
+  };
+}
+
+export async function createList(
+  client: SupabaseClient,
+  name: string,
+  householdId: string | null,
+): Promise<Outcome<string>> {
+  // `owner_id` is left out on purpose. The column defaults to auth.uid(), which is the
+  // same value the insert policy checks it against, so a client that sends it can only
+  // ever agree with the default or be rejected by the policy. One that never names the
+  // column cannot get it wrong.
+  const { data, error } = await client
+    .from('lists')
+    .insert({ name: name.trim(), household_id: householdId })
+    .select('id')
+    .single();
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: (data as { id: string }).id };
+}
+
+export async function renameList(
+  client: SupabaseClient,
+  listId: string,
+  name: string,
+): Promise<Outcome<void>> {
+  // `.eq('id', ...)` names the row; it does not authorise the write. The update policy's
+  // `using` clause is what decides whether the caller may touch it, and the column-level
+  // grant is what stops this statement reaching `household_id` or `owner_id`.
+  const { error } = await client
+    .from('lists')
+    .update({ name: name.trim() })
+    .eq('id', listId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+export async function removeList(
+  client: SupabaseClient,
+  listId: string,
+): Promise<Outcome<void>> {
+  // Soft delete, and the only kind available: there is no DELETE policy on `lists` and
+  // deliberately never will be. Supabase does not apply RLS to DELETE, so a hard delete
+  // would broadcast the row's primary key to every subscriber of the table regardless of
+  // household. Removal as an UPDATE is filtered like any other, and it cascades to
+  // nothing — the list's items keep their own `deleted_at` untouched and simply stop
+  // being reachable through a list that no longer loads.
+  const { error } = await client
+    .from('lists')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', listId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+export async function promoteList(
+  client: SupabaseClient,
+  listId: string,
+): Promise<Outcome<void>> {
+  // The one write in this slice that is not a direct table update. Promotion has real
+  // conditions RLS cannot express in a `with check` — owner only, own household only,
+  // caller must be a member, not already shared — and it is one-way, so it publishes
+  // item text that was private until the moment it runs. Callers confirm before calling.
+  const { error } = await client.rpc('promote_to_household', {
+    target_list_id: listId,
+  });
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+export async function loadItems(
+  client: SupabaseClient,
+  listId: string,
+): Promise<Outcome<ListItemRow[]>> {
+  // Both order clauses are load-bearing. `position` is a fractional key, so two members
+  // moving an item into the same gap while offline of each other can compute the *same*
+  // key — that is a designed-for outcome, not a bug, and it is also what makes the
+  // read-then-write in addItem() benign. `id` then breaks the tie identically on every
+  // device, which is the difference between two screens agreeing and two screens
+  // disagreeing about a list they are both looking at.
+  //
+  // The `position` column is `collate "C"`; base-62 keys only sort correctly under byte
+  // order, and this database's default collation says 'a1' < 'A1' where byte order says
+  // the opposite. Sorting here rather than in JS keeps that agreement in one place.
+  const { data, error } = await client
+    .from('list_items')
+    .select('id, name, position, checked_at')
+    .eq('list_id', listId)
+    .is('deleted_at', null)
+    .order('position')
+    .order('id');
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as ListItemRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      position: row.position,
+      checkedAt: row.checked_at,
+    })),
+  };
+}
+
+export async function addItem(
+  client: SupabaseClient,
+  listId: string,
+  name: string,
+  lastPosition: string | null,
+): Promise<Outcome<string>> {
+  // New items always append, so the upper bound is null and `lastPosition` is the
+  // position of the last item the caller can see — null for an empty list. Two members
+  // appending at once therefore compute the same key from the same view, which the `id`
+  // tie-break in loadItems() resolves without either write failing.
+  const key = keyBetween(lastPosition, null);
+
+  if (!key.ok) {
+    return key;
+  }
+
+  const { data, error } = await client
+    .from('list_items')
+    .insert({ list_id: listId, name: name.trim(), position: key.value })
+    .select('id')
+    .single();
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: (data as { id: string }).id };
+}
+
+export async function renameItem(
+  client: SupabaseClient,
+  itemId: string,
+  name: string,
+): Promise<Outcome<void>> {
+  const { error } = await client
+    .from('list_items')
+    .update({ name: name.trim() })
+    .eq('id', itemId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+export async function removeItem(
+  client: SupabaseClient,
+  itemId: string,
+): Promise<Outcome<void>> {
+  // Soft delete for the same reason as removeList(): DELETE is not RLS-filtered, so it
+  // is not granted on this table at all. The row keeps its `position`, which is what
+  // makes an undo in a later slice a matter of clearing one column.
+  const { error } = await client
+    .from('list_items')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', itemId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+export async function setChecked(
+  client: SupabaseClient,
+  itemId: string,
+  checked: boolean,
+): Promise<Outcome<void>> {
+  // Check-off never writes `position`. One gesture, one fact: a checked item stays where
+  // it is, and grouping checked items at the bottom is a sort at render time, not a
+  // rewrite of everyone else's order.
+  //
+  // The timestamp is stored rather than a boolean because it answers "is it checked" and
+  // "when" for the price of the first question alone.
+  const { error } = await client
+    .from('list_items')
+    .update({ checked_at: checked ? new Date().toISOString() : null })
+    .eq('id', itemId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Moves one item into the gap between two others, writing exactly one row.
+ *
+ * The two bounds are the positions of the items that will sit either side of the moved
+ * item once it lands, taken from the list as currently rendered and *excluding* the item
+ * being moved. For a list sorted as `loadItems` returns it, moving the item at index `i`
+ * up one place lands it between `items[i - 2]` and `items[i - 1]`; moving it down lands
+ * it between `items[i + 1]` and `items[i + 2]`. At the ends of the list the missing
+ * neighbour is null — moving the second item up gives `(null, items[0].position)`, and
+ * moving the second-to-last down gives `(items[last].position, null)`.
+ *
+ * Getting the off-by-one wrong here does not throw; it produces a move that appears not
+ * to have happened, because the new key lands back in the gap the item came from.
+ */
+export async function moveItem(
+  client: SupabaseClient,
+  itemId: string,
+  beforePosition: string | null,
+  afterPosition: string | null,
+): Promise<Outcome<void>> {
+  const key = keyBetween(beforePosition, afterPosition);
+
+  if (!key.ok) {
+    return key;
+  }
+
+  const { error } = await client
+    .from('list_items')
+    .update({ position: key.value })
+    .eq('id', itemId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Every route's parameters, in one place. React Navigation cannot check a route
+ * parameter it has not been told about, and a deep link is the one caller that can
+ * arrive with any shape at all — an untyped param is `undefined` at runtime the
+ * first time someone opens a hand-edited URL.
+ *
+ * This lives beside the navigator rather than inside `App.tsx` because the screens
+ * need it to type their own props, and a screen importing the app's entry point to
+ * get a type is a cycle waiting for someone to add a value to it.
+ *
+ * `HouseholdSetup` and `Household` are both listed even though only one of them is
+ * ever registered at a time. Which one exists is a fact about the data, not about
+ * the route table, and the alternative — one route that branches inside — would let
+ * a caller navigate to the household screen without a household.
+ */
+export type RootStackParamList = {
+  Lists: undefined;
+  ListDetail: { listId: string };
+  HouseholdSetup: undefined;
+  Household: undefined;
+};

--- a/mobile/src/screens/ConfigErrorScreen.tsx
+++ b/mobile/src/screens/ConfigErrorScreen.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme/ThemeProvider';
 import type { Tokens } from '../theme/tokens';

--- a/mobile/src/screens/HouseholdScreen.tsx
+++ b/mobile/src/screens/HouseholdScreen.tsx
@@ -6,12 +6,12 @@ import {
   Body,
   Card,
   ErrorNote,
-  Heading,
+  NAVIGATOR_EDGES,
   PrimaryButton,
   Screen,
   SecondaryButton,
 } from '../components/ui';
-import { createInvite, type Household, type Invite } from '../lib/household';
+import { createInvite, type Invite } from '../lib/household';
 import { useTheme } from '../theme/ThemeProvider';
 import type { Tokens } from '../theme/tokens';
 
@@ -21,15 +21,17 @@ import type { Tokens } from '../theme/tokens';
  *
  * There is no "remove member" or "make admin" control, and that is not an omission:
  * every member is equal rank by spec, so there is no rank for a control to change.
+ *
+ * The household's name is missing here on purpose: the navigator header carries it,
+ * because that header is also what carries back. Naming it twice on one screen was
+ * what the header replaced.
  */
 export function HouseholdScreen({
   client,
-  household,
   memberCount,
   onRefresh,
 }: {
   client: SupabaseClient;
-  household: Household;
   memberCount: number;
   onRefresh: () => void;
 }) {
@@ -55,8 +57,7 @@ export function HouseholdScreen({
   }
 
   return (
-    <Screen>
-      <Heading>{household.name}</Heading>
+    <Screen edges={NAVIGATOR_EDGES}>
       <Body>
         {memberCount === 1
           ? 'Just you so far.'

--- a/mobile/src/screens/HouseholdSetupScreen.tsx
+++ b/mobile/src/screens/HouseholdSetupScreen.tsx
@@ -7,6 +7,7 @@ import {
   ErrorNote,
   Field,
   Heading,
+  NAVIGATOR_EDGES,
   PrimaryButton,
   Screen,
   SecondaryButton,
@@ -68,7 +69,7 @@ export function HouseholdSetupScreen({
 
   if (mode === 'create') {
     return (
-      <Screen>
+      <Screen edges={NAVIGATOR_EDGES}>
         <Heading>Name your household</Heading>
         <Body>Everyone who joins sees this name. You can be the only member.</Body>
         <Field
@@ -101,7 +102,7 @@ export function HouseholdSetupScreen({
 
   if (mode === 'join') {
     return (
-      <Screen>
+      <Screen edges={NAVIGATOR_EDGES}>
         <Heading>Enter the code</Heading>
         <Body>
           Ask whoever set up the household for their invite code. Codes work once and
@@ -139,8 +140,7 @@ export function HouseholdSetupScreen({
   }
 
   return (
-    <Screen>
-      <Heading>Cartel</Heading>
+    <Screen edges={NAVIGATOR_EDGES}>
       <Body>
         Share a shopping list with the people you live with. You can do this later —
         your own lists work without a household.

--- a/mobile/src/screens/ListDetailScreen.tsx
+++ b/mobile/src/screens/ListDetailScreen.tsx
@@ -1,0 +1,360 @@
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  Badge,
+  CheckTarget,
+  Confirm,
+  EmptyState,
+  ErrorNote,
+  Field,
+  IconButton,
+  NAVIGATOR_EDGES,
+  PrimaryButton,
+  Row,
+  Screen,
+  SecondaryButton,
+} from '../components/ui';
+import { useListItems } from '../hooks/useListItems';
+import type { ListsView } from '../hooks/useLists';
+import type { Outcome } from '../lib/household';
+import {
+  addItem,
+  moveItem,
+  promoteList,
+  removeItem,
+  renameItem,
+  setChecked,
+  type ListItemRow,
+} from '../lib/lists';
+import type { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../theme/ThemeProvider';
+import type { Tokens } from '../theme/tokens';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ListDetail'> & {
+  client: SupabaseClient;
+  lists: ListsView;
+  onListsChanged: () => Promise<void>;
+  inHousehold: boolean;
+};
+
+/**
+ * One list, and everything you can do to it.
+ *
+ * The list's own name and scope come from the loaded index rather than a query of
+ * their own, which is also what makes the not-found case answerable: RLS returns no
+ * row for a list the caller cannot see, so a stale deep link, a foreign id and a
+ * removed list are the same absence, and none of them can be told apart by asking
+ * again.
+ */
+export function ListDetailScreen({
+  client,
+  inHousehold,
+  lists,
+  navigation,
+  onListsChanged,
+  route,
+}: Props) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { listId } = route.params;
+  const { view, refresh } = useListItems(client, listId);
+
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const [confirmingShare, setConfirmingShare] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const list =
+    lists.status === 'loaded'
+      ? lists.lists.find((candidate) => candidate.id === listId) ?? null
+      : null;
+
+  useLayoutEffect(() => {
+    // The header carries the list's name for the same reason it carries the
+    // household's on the household screen: it is also what carries back, and naming
+    // the same thing twice on one screen is what the header replaced.
+    if (list) {
+      navigation.setOptions({ title: list.name });
+    }
+  }, [list, navigation]);
+
+  /**
+   * Every write on this screen is the same four steps — mark busy, clear the last
+   * error, write, reload — differing only in the write itself and in what gets
+   * cleared afterwards. Spelled out seven times, the plumbing is what you read and
+   * the write is what you skim past. `after` runs only on success, which is why the
+   * caller's cleanup belongs there rather than below the await.
+   */
+  async function mutate(
+    write: () => Promise<Outcome<unknown>>,
+    after?: () => void | Promise<void>,
+  ) {
+    setBusy(true);
+    setError(null);
+
+    const outcome = await write();
+
+    if (!outcome.ok) {
+      setBusy(false);
+      setError(outcome.message);
+      return;
+    }
+
+    await refresh();
+    await after?.();
+    setBusy(false);
+  }
+
+  function add(items: ListItemRow[]) {
+    // The Add button is disabled on an empty draft, but the keyboard's return key
+    // reaches here regardless. `list_items.name` carries a length check, so without
+    // this the round trip comes back as raw constraint prose that `humanise` has no
+    // mapping for and shows the user the schema.
+    if (draft.trim().length === 0) {
+      return;
+    }
+
+    // New items append, so the lower bound is the last item the caller can see and
+    // the upper bound is nothing at all.
+    const last = items.length > 0 ? items[items.length - 1].position : null;
+
+    void mutate(
+      () => addItem(client, listId, draft, last),
+      () => setDraft(''),
+    );
+  }
+
+  function commitRename() {
+    const id = editingId;
+
+    if (!id || editingName.trim().length === 0) {
+      return;
+    }
+
+    void mutate(
+      () => renameItem(client, id, editingName),
+      () => setEditingId(null),
+    );
+  }
+
+  function moveUp(index: number, items: ListItemRow[]) {
+    // Neighbours are read from the rendered order and exclude the item being moved,
+    // exactly as moveItem() documents: up one place lands between items[index - 2]
+    // and items[index - 1], and the missing neighbour at the top reads as null.
+    void mutate(() =>
+      moveItem(
+        client,
+        items[index].id,
+        index >= 2 ? items[index - 2].position : null,
+        items[index - 1].position,
+      ),
+    );
+  }
+
+  function moveDown(index: number, items: ListItemRow[]) {
+    void mutate(() =>
+      moveItem(
+        client,
+        items[index].id,
+        items[index + 1].position,
+        index + 2 < items.length ? items[index + 2].position : null,
+      ),
+    );
+  }
+
+  function share() {
+    void mutate(
+      () => promoteList(client, listId),
+      async () => {
+        // The scope lives on the list row, not on the items, so the index is what has
+        // to be reloaded for this screen's badge — and the index's own — to agree
+        // with the database. Both screens read the same loaded lists, so one reload
+        // settles both.
+        await onListsChanged();
+        setConfirmingShare(false);
+      },
+    );
+  }
+
+  if (lists.status === 'loading') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ActivityIndicator color={tokens.color.accent} size="large" />
+      </Screen>
+    );
+  }
+
+  if (lists.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={lists.message} />
+      </Screen>
+    );
+  }
+
+  if (!list) {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <EmptyState
+          heading="This list isn’t here"
+          body="It may have been removed, or it may belong to someone else — lists are private until they are shared with a household."
+          actionLabel="Back to your lists"
+          onAction={() => navigation.navigate('Lists')}
+        />
+      </Screen>
+    );
+  }
+
+  const items = view.status === 'loaded' ? view.items : [];
+  const canShare = list.householdId === null && inHousehold;
+
+  return (
+    <Screen edges={NAVIGATOR_EDGES} align="top" scroll>
+      <Badge label={list.householdId ? 'Shared' : 'Personal'} />
+
+      <Field
+        label="Add an item"
+        value={draft}
+        onChangeText={setDraft}
+        placeholder="Milk"
+        autoCapitalize="sentences"
+        maxLength={120}
+        editable={!busy}
+        onSubmitEditing={() => add(items)}
+        returnKeyType="done"
+      />
+      <PrimaryButton
+        label="Add"
+        onPress={() => add(items)}
+        busy={busy}
+        disabled={draft.trim().length === 0}
+      />
+
+      {error ? <ErrorNote message={error} /> : null}
+
+      {view.status === 'loading' ? (
+        <ActivityIndicator color={tokens.color.accent} />
+      ) : null}
+
+      {view.status === 'error' ? <ErrorNote message={view.message} /> : null}
+
+      {view.status === 'loaded' && items.length === 0 ? (
+        <EmptyState
+          heading="Nothing on it yet"
+          body="Whatever you add goes to the bottom of the list."
+        />
+      ) : null}
+
+      {items.map((item, index) =>
+        item.id === editingId ? (
+          <View key={item.id} style={styles.editor}>
+            <Field
+              label="Item name"
+              value={editingName}
+              onChangeText={setEditingName}
+              autoFocus
+              maxLength={120}
+              editable={!busy}
+              onSubmitEditing={commitRename}
+              returnKeyType="done"
+            />
+            <SecondaryButton
+              label="Save"
+              onPress={commitRename}
+              disabled={busy || editingName.trim().length === 0}
+            />
+            <SecondaryButton
+              label="Cancel"
+              onPress={() => setEditingId(null)}
+              disabled={busy}
+            />
+          </View>
+        ) : (
+          <Row
+            key={item.id}
+            label={item.name}
+            onPress={() => {
+              setError(null);
+              setEditingName(item.name);
+              setEditingId(item.id);
+            }}
+            leading={
+              <CheckTarget
+                checked={item.checkedAt !== null}
+                onToggle={() =>
+                  void mutate(() =>
+                    setChecked(client, item.id, item.checkedAt === null),
+                  )
+                }
+                accessibilityLabel={item.name}
+                disabled={busy}
+              />
+            }
+            trailing={
+              <View style={styles.rowActions}>
+                <IconButton
+                  glyph="↑"
+                  accessibilityLabel={`Move ${item.name} up`}
+                  onPress={() => moveUp(index, items)}
+                  disabled={busy || index === 0}
+                />
+                <IconButton
+                  glyph="↓"
+                  accessibilityLabel={`Move ${item.name} down`}
+                  onPress={() => moveDown(index, items)}
+                  disabled={busy || index === items.length - 1}
+                />
+                <IconButton
+                  glyph="×"
+                  accessibilityLabel={`Remove ${item.name}`}
+                  onPress={() => void mutate(() => removeItem(client, item.id))}
+                  disabled={busy}
+                />
+              </View>
+            }
+          />
+        ),
+      )}
+
+      {canShare && confirmingShare ? (
+        <Confirm
+          message="Sharing puts this list, and everything on it, in front of everyone in your household. There is no way to make it private again."
+          confirmLabel="Share with household"
+          onConfirm={share}
+          onCancel={() => setConfirmingShare(false)}
+          busy={busy}
+        />
+      ) : null}
+
+      {canShare && !confirmingShare ? (
+        <SecondaryButton
+          label="Share with household"
+          onPress={() => {
+            setError(null);
+            setConfirmingShare(true);
+          }}
+          disabled={busy}
+        />
+      ) : null}
+    </Screen>
+  );
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    editor: {
+      gap: tokens.space.sm,
+    },
+    // No gap: each of these controls already carries the 44pt box around its glyph,
+    // and spacing them further pushes the item's name off the end of a phone row.
+    rowActions: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+  });
+}

--- a/mobile/src/screens/ListsScreen.tsx
+++ b/mobile/src/screens/ListsScreen.tsx
@@ -1,0 +1,229 @@
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  Badge,
+  CheckTarget,
+  EmptyState,
+  ErrorNote,
+  Field,
+  NAVIGATOR_EDGES,
+  PrimaryButton,
+  Row,
+  Screen,
+  SecondaryButton,
+} from '../components/ui';
+import type { ListsView } from '../hooks/useLists';
+import type { Household } from '../lib/household';
+import { createList } from '../lib/lists';
+import type { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../theme/ThemeProvider';
+import type { Tokens } from '../theme/tokens';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Lists'> & {
+  client: SupabaseClient;
+  view: ListsView;
+  refresh: () => Promise<void>;
+  household: Household | null;
+};
+
+/**
+ * The home screen, for everyone.
+ *
+ * Not the household screen, and not conditionally: a user who has never created or
+ * joined a household still has lists, and Slice 2's acceptance test says so outright.
+ * The household is reached from here instead — an offer in the header rather than the
+ * wall the app opens with.
+ */
+export function ListsScreen({
+  client,
+  household,
+  navigation,
+  refresh,
+  view,
+}: Props) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const [composing, setComposing] = useState(false);
+  const [name, setName] = useState('');
+  const [shared, setShared] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      // The header is the only place a control can sit without competing with the
+      // list for the top of the screen, and it is where the destination — a different
+      // place, not a mode of this one — belongs.
+      headerRight: () => (
+        <Pressable
+          accessibilityRole="button"
+          onPress={() =>
+            household
+              ? navigation.navigate('Household')
+              : navigation.navigate('HouseholdSetup')
+          }
+          style={({ pressed }) => [
+            styles.headerButton,
+            pressed && styles.headerButtonPressed,
+          ]}
+        >
+          <Text style={styles.headerButtonLabel}>Household</Text>
+        </Pressable>
+      ),
+    });
+  }, [household, navigation, styles]);
+
+  function beginComposing() {
+    setError(null);
+    setName('');
+    setShared(false);
+    setComposing(true);
+  }
+
+  function cancelComposing() {
+    setError(null);
+    setComposing(false);
+  }
+
+  async function submit() {
+    // The button is disabled on an empty name, but the keyboard's return key is not.
+    // `lists.name` carries a length check, and an empty one comes back as raw
+    // constraint prose that `humanise` has no mapping for.
+    if (name.trim().length === 0) {
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+
+    const outcome = await createList(
+      client,
+      name,
+      shared && household ? household.id : null,
+    );
+
+    if (!outcome.ok) {
+      setBusy(false);
+      setError(outcome.message);
+      return;
+    }
+
+    // Awaited before navigating, not after. The detail screen reads its list's name
+    // and scope out of this same loaded index, so a list that is not in it yet reads
+    // there as a list that does not exist.
+    await refresh();
+
+    setBusy(false);
+    setComposing(false);
+    setName('');
+    setShared(false);
+    navigation.navigate('ListDetail', { listId: outcome.value });
+  }
+
+  const lists = view.status === 'loaded' ? view.lists : [];
+
+  return (
+    <Screen edges={NAVIGATOR_EDGES} align="top" scroll>
+      {view.status === 'loading' ? (
+        <ActivityIndicator color={tokens.color.accent} size="large" />
+      ) : null}
+
+      {view.status === 'error' ? <ErrorNote message={view.message} /> : null}
+
+      {lists.map((list) => (
+        <Row
+          key={list.id}
+          label={list.name}
+          trailing={<Badge label={list.householdId ? 'Shared' : 'Personal'} />}
+          onPress={() => navigation.navigate('ListDetail', { listId: list.id })}
+        />
+      ))}
+
+      {error ? <ErrorNote message={error} /> : null}
+
+      {composing ? (
+        <View style={styles.composer}>
+          <Field
+            label="List name"
+            value={name}
+            onChangeText={setName}
+            placeholder="Weekly shop"
+            autoCapitalize="sentences"
+            autoFocus
+            maxLength={60}
+            editable={!busy}
+            onSubmitEditing={submit}
+            returnKeyType="done"
+          />
+          {household ? (
+            // A checkbox rather than a pair of buttons: there are two scopes, one of
+            // them is the default, and the difference between them is whether other
+            // people can see the list. That is a thing you opt into, and saying so in
+            // the household's own name is shorter than explaining what "Household"
+            // would have meant.
+            <Row
+              label={`Share with ${household.name}`}
+              leading={
+                <CheckTarget
+                  checked={shared}
+                  onToggle={() => setShared(!shared)}
+                  accessibilityLabel={`Share with ${household.name}`}
+                  disabled={busy}
+                />
+              }
+            />
+          ) : null}
+          <PrimaryButton
+            label="Create list"
+            onPress={submit}
+            busy={busy}
+            disabled={name.trim().length === 0}
+          />
+          <SecondaryButton
+            label="Cancel"
+            onPress={cancelComposing}
+            disabled={busy}
+          />
+        </View>
+      ) : view.status === 'loaded' && lists.length === 0 ? (
+        <EmptyState
+          heading="No lists yet."
+          body={
+            household
+              ? 'Make one for yourself, or one the whole household can see.'
+              : 'Make one for yourself. You can share it with a household later.'
+          }
+          actionLabel="New list"
+          onAction={beginComposing}
+        />
+      ) : view.status === 'loaded' ? (
+        <PrimaryButton label="New list" onPress={beginComposing} />
+      ) : null}
+    </Screen>
+  );
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    composer: {
+      gap: tokens.space.sm,
+    },
+    headerButton: {
+      minHeight: tokens.minTouchTarget,
+      justifyContent: 'center',
+      paddingHorizontal: tokens.space.sm,
+      borderRadius: tokens.radius.md,
+    },
+    headerButtonPressed: {
+      backgroundColor: tokens.color.surfaceSunken,
+    },
+    headerButtonLabel: {
+      color: tokens.color.accent,
+      fontSize: tokens.fontSize.body,
+      fontWeight: '600',
+    },
+  });
+}

--- a/supabase/migrations/20260810000002_allow_authenticated_to_execute_current_household_id.sql
+++ b/supabase/migrations/20260810000002_allow_authenticated_to_execute_current_household_id.sql
@@ -1,4 +1,5 @@
--- Fixes a break introduced by the blanket revoke in the previous migration.
+-- Fixes a break introduced by the blanket revoke at the end of
+-- 20260810000000_household_identity.sql, not by the previous migration.
 --
 -- RLS policy expressions are evaluated as the querying user, not as the table owner.
 -- A policy that calls a function the caller cannot execute fails with "permission

--- a/supabase/migrations/20260810000003_lists_and_items.sql
+++ b/supabase/migrations/20260810000003_lists_and_items.sql
@@ -1,0 +1,158 @@
+-- Slice 2 — Lists & Items.
+--
+-- Access shape: writes go DIRECT TO TABLE under RLS `with check` here, deliberately
+-- unlike Slice 1's write-through-RPC split. That split exists for invariants RLS
+-- cannot express atomically, and this slice has none — "you may only write a list you
+-- can see" and "you may only create a household list in *your* household" are both
+-- plain check expressions. Promotion is the one exception: it has real conditions
+-- (owner only, own household only, caller must be a member), so it keeps its RPC.
+--
+-- `deleted_at` is never referenced in any policy, and must not be. Removal is a soft
+-- delete, i.e. an UPDATE. Realtime authorises each event against the subscriber's
+-- SELECT policy evaluated on the *new* row, so a policy saying `deleted_at is null`
+-- would filter out the very UPDATE that performs the deletion — other household
+-- members would never see the removal, and soft delete would have bought nothing.
+-- Filtering `deleted_at` is the client query's job. The accepted consequence is that
+-- soft-deleted rows stay readable by household members; "deleted" here means hidden
+-- by the client, which is a weaker claim than the word suggests.
+--
+-- Every membership test uses `=`, never `is not distinct from`. For a user with no
+-- household `current_household_id()` returns null, so `household_id = null` is null →
+-- false and personal lists match on ownership alone. Written the other way,
+-- `null is not distinct from null` is *true* and every householdless user would see
+-- every other householdless user's lists. `supabase/tests/rls_lists.sql` asserts this.
+--
+-- The column-level UPDATE grants below are the enforcement mechanism for "no
+-- demotion, no reassignment". A `with check` expression cannot see the OLD row, so it
+-- cannot express "household_id may not change". Withholding the column privilege can:
+-- a direct client update touching `lists.household_id`, `lists.owner_id`,
+-- `list_items.list_id` or `list_items.id` fails with "permission denied for column",
+-- while promote_to_household() is unaffected because SECURITY DEFINER runs it as the
+-- function owner. Demotion has no function and deliberately gets none — the want
+-- behind it is copy, which is Slice 9's job.
+
+create table public.lists (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid not null default auth.uid() references auth.users (id) on delete cascade,
+  -- household_id is the *only* record of scope; null means personal. There is no
+  -- `type` column, which would be the same fact stored twice with two of its four
+  -- states invalid.
+  household_id uuid references public.households (id) on delete cascade,
+  name text not null check (length(trim(name)) between 1 and 60),
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create index lists_owner_id_idx on public.lists (owner_id);
+create index lists_household_id_idx on public.lists (household_id);
+
+create table public.list_items (
+  id uuid primary key default gen_random_uuid(),
+  list_id uuid not null references public.lists (id) on delete cascade,
+  name text not null check (length(trim(name)) between 1 and 120),
+  -- Fractional base-62 key, sorted `order by position, id`. Declared collate "C"
+  -- because base-62 sorts correctly only under byte order; this database is
+  -- en_US.UTF-8 under ICU, where 'a1' < 'A1' is true and byte order says the
+  -- opposite. The key generator and the column must agree on collation or neither
+  -- is correct. Left to the default the ordering goes silently wrong, and only once
+  -- mixed-case keys exist — around the sixty-third insert into one list.
+  position text collate "C" not null,
+  -- Replaces the `checked` boolean: strictly more information for one column.
+  checked_at timestamptz,
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create index list_items_list_id_position_idx
+  on public.list_items (list_id, position, id);
+
+alter table public.lists enable row level security;
+alter table public.list_items enable row level security;
+
+create policy lists_select_visible on public.lists
+  for select to authenticated
+  using (owner_id = (select auth.uid()) or household_id = public.current_household_id());
+
+create policy lists_insert_own on public.lists
+  for insert to authenticated
+  with check (
+    owner_id = (select auth.uid())
+    and (household_id is null or household_id = public.current_household_id())
+  );
+
+create policy lists_update_visible on public.lists
+  for update to authenticated
+  using (owner_id = (select auth.uid()) or household_id = public.current_household_id())
+  with check (owner_id = (select auth.uid()) or household_id = public.current_household_id());
+
+-- No DELETE policy on either table. Removal is a soft delete, so hard delete must be
+-- *unavailable*, not merely unused: Supabase does not apply RLS to DELETE statements,
+-- so a hard delete would broadcast to every subscriber of the table regardless of
+-- household.
+
+-- Item visibility delegates to the parent list's, rather than restating it. RLS on
+-- public.lists applies inside this subquery because policy expressions run as the
+-- querying user, so a row whose list is invisible has no visible items.
+create policy list_items_select_visible on public.list_items
+  for select to authenticated
+  using (exists (select 1 from public.lists l where l.id = public.list_items.list_id));
+
+create policy list_items_insert_visible on public.list_items
+  for insert to authenticated
+  with check (exists (select 1 from public.lists l where l.id = public.list_items.list_id));
+
+create policy list_items_update_visible on public.list_items
+  for update to authenticated
+  using (exists (select 1 from public.lists l where l.id = public.list_items.list_id))
+  with check (exists (select 1 from public.lists l where l.id = public.list_items.list_id));
+
+-- Promotion is one-way and confirmed in the UI before it runs. It publishes existing
+-- item text to the household, which is why it is a deliberate act with conditions
+-- rather than an editable column.
+create or replace function public.promote_to_household(target_list_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller uuid := (select auth.uid());
+  caller_household uuid;
+  list_owner uuid;
+  current_scope uuid;
+begin
+  if caller is null then raise exception 'not_authenticated'; end if;
+
+  select household_id into caller_household
+  from public.household_members
+  where user_id = caller;
+
+  if caller_household is null then raise exception 'not_in_household'; end if;
+
+  select owner_id, household_id into list_owner, current_scope
+  from public.lists
+  where id = target_list_id and deleted_at is null;
+
+  if list_owner is null then raise exception 'list_not_found'; end if;
+  if list_owner <> caller then raise exception 'not_list_owner'; end if;
+  if current_scope is not null then raise exception 'already_shared'; end if;
+
+  update public.lists set household_id = caller_household where id = target_list_id;
+end;
+$$;
+
+-- Supabase's default privileges grant ALL on new public-schema tables to anon and
+-- authenticated, so without the blanket revoke the grants below would be additions to
+-- an already-open door rather than the whole of the door. Same reasoning as migration
+-- 20260810000001 applied to tables instead of functions.
+revoke all on table public.lists from anon, authenticated;
+revoke all on table public.list_items from anon, authenticated;
+revoke execute on function public.promote_to_household(uuid) from public, anon;
+
+grant select, insert on table public.lists to authenticated;
+grant update (name, deleted_at) on table public.lists to authenticated;
+
+grant select, insert on table public.list_items to authenticated;
+grant update (name, position, checked_at, deleted_at) on table public.list_items to authenticated;
+
+grant execute on function public.promote_to_household(uuid) to authenticated;

--- a/supabase/tests/rls_lists.sql
+++ b/supabase/tests/rls_lists.sql
@@ -1,0 +1,252 @@
+-- RLS policy tests for public.lists and public.list_items (Slice 2).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- There is no local Supabase CLI, no config.toml and no Docker in this project —
+-- Slice 0 deferred test infrastructure and no later slice picks it up. This file is
+-- the deliberately narrow substitute: SQL-level assertions about RLS only, run
+-- against the hosted project inside a transaction that is thrown away.
+--
+-- WHAT IT IS REALLY GUARDING. The policies compare household membership with `=`,
+-- never `is not distinct from`. For a user with no household `current_household_id()`
+-- returns null, so `household_id = null` is null → false and a personal list matches
+-- on ownership alone. Written with `is not distinct from`, `null = null` is *true*
+-- and every householdless user sees every other householdless user's lists — a
+-- household-privacy break of the class 03-SPEC.md § 0 calls a hard invariant
+-- violation. Assertion 1 is the one that catches it: B and C both have no household,
+-- so it exercises exactly the null-vs-null comparison.
+--
+-- Fixtures are the premise, not the thing under test, so they are inserted as the
+-- owning role, which bypasses RLS. Only the assertions run as `authenticated`.
+-- `request.jwt.claims` must be set *before* the role switch: after it, the session
+-- no longer has the privilege to set the GUC on some configurations, and auth.uid()
+-- reads that GUC.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. A and D share a household. B and C have none — that is the point of
+-- them, not an oversight.
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-00000000000a', true),  -- A: household, 1 personal + 1 household list
+  ('00000000-0000-4000-8000-00000000000b', true),  -- B: no household
+  ('00000000-0000-4000-8000-00000000000c', true),  -- C: no household
+  ('00000000-0000-4000-8000-00000000000d', true);  -- D: same household as A
+
+insert into public.households (id, name) values
+  ('10000000-0000-4000-8000-000000000001', 'Test Household');
+
+insert into public.household_members (user_id, household_id) values
+  ('00000000-0000-4000-8000-00000000000a', '10000000-0000-4000-8000-000000000001'),
+  ('00000000-0000-4000-8000-00000000000d', '10000000-0000-4000-8000-000000000001');
+
+insert into public.lists (id, owner_id, household_id, name) values
+  ('20000000-0000-4000-8000-000000000001',
+   '00000000-0000-4000-8000-00000000000a', null,
+   'A personal'),
+  ('20000000-0000-4000-8000-000000000002',
+   '00000000-0000-4000-8000-00000000000a', '10000000-0000-4000-8000-000000000001',
+   'A household'),
+  ('20000000-0000-4000-8000-000000000003',
+   '00000000-0000-4000-8000-00000000000b', null,
+   'B personal'),
+  ('20000000-0000-4000-8000-000000000004',
+   '00000000-0000-4000-8000-00000000000c', null,
+   'C personal');
+
+insert into public.list_items (id, list_id, name, position) values
+  ('30000000-0000-4000-8000-000000000001',
+   '20000000-0000-4000-8000-000000000001', 'A personal item', 'a0'),
+  ('30000000-0000-4000-8000-000000000002',
+   '20000000-0000-4000-8000-000000000002', 'A household item', 'a0'),
+  ('30000000-0000-4000-8000-000000000003',
+   '20000000-0000-4000-8000-000000000003', 'B personal item', 'a0'),
+  ('30000000-0000-4000-8000-000000000004',
+   '20000000-0000-4000-8000-000000000004', 'C personal item', 'a0');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control, as B.
+-- Without this, every "must be 0" assertion below would also pass if the policies
+-- hid absolutely everything, including from the owner.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000000b","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.lists
+      where id = '20000000-0000-4000-8000-000000000003') <> 1 then
+    raise exception 'FAIL: B cannot see B''s own personal list (policies hide everything; the zero-row assertions below prove nothing)';
+  end if;
+
+  if (select count(*) from public.list_items
+      where id = '30000000-0000-4000-8000-000000000003') <> 1 then
+    raise exception 'FAIL: B cannot see the item on B''s own personal list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — two householdless users cannot see each other. THE null = null case.
+-- Assertion 2 — a non-member cannot see a household list.
+-- Assertion 4 (lists half) — same two questions asked of list_items.
+-- All as B.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000000b","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.lists
+      where id = '20000000-0000-4000-8000-000000000004') <> 0 then
+    raise exception 'FAIL: B (no household) can see C''s (no household) personal list — membership is being compared with IS NOT DISTINCT FROM, so null = null matched';
+  end if;
+
+  if (select count(*) from public.list_items
+      where id = '30000000-0000-4000-8000-000000000004') <> 0 then
+    raise exception 'FAIL: B (no household) can see the item on C''s (no household) personal list';
+  end if;
+
+  if (select count(*) from public.lists
+      where id = '20000000-0000-4000-8000-000000000002') <> 0 then
+    raise exception 'FAIL: B (not a member) can see A''s household list';
+  end if;
+
+  if (select count(*) from public.list_items
+      where id = '30000000-0000-4000-8000-000000000002') <> 0 then
+    raise exception 'FAIL: B (not a member) can see the item on A''s household list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1, symmetric half — as C, looking for B's list. Asked in both
+-- directions because a policy can be asymmetric in ways one direction hides.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000000c","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.lists
+      where id = '20000000-0000-4000-8000-000000000003') <> 0 then
+    raise exception 'FAIL: C (no household) can see B''s (no household) personal list';
+  end if;
+
+  if (select count(*) from public.list_items
+      where id = '30000000-0000-4000-8000-000000000003') <> 0 then
+    raise exception 'FAIL: C (no household) can see the item on B''s (no household) personal list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — as D, A's household-mate: A's personal list stays private, A's
+-- household list is visible. Assertion 4's other half asks the same of the items,
+-- because item visibility delegates through a nested EXISTS onto public.lists and
+-- that delegation is an assumption worth testing rather than reasoning about.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000000d","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.lists
+      where id = '20000000-0000-4000-8000-000000000001') <> 0 then
+    raise exception 'FAIL: D can see A''s personal list — personal is not staying private inside a household';
+  end if;
+
+  if (select count(*) from public.list_items
+      where id = '30000000-0000-4000-8000-000000000001') <> 0 then
+    raise exception 'FAIL: D can see the item on A''s personal list';
+  end if;
+
+  if (select count(*) from public.lists
+      where id = '20000000-0000-4000-8000-000000000002') <> 1 then
+    raise exception 'FAIL: D cannot see A''s household list — household lists are not reaching members';
+  end if;
+
+  if (select count(*) from public.list_items
+      where id = '30000000-0000-4000-8000-000000000002') <> 1 then
+    raise exception 'FAIL: D cannot see the item on A''s household list — item visibility is not delegating through the parent list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 5 — no demotion. `with check` cannot see OLD, so it cannot express
+-- "household_id may not change"; the withheld column-level UPDATE grant does. The
+-- failure being caught here is the update SILENTLY SUCCEEDING, not it erroring.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000000a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    update public.lists
+    set household_id = null
+    where id = '20000000-0000-4000-8000-000000000002';
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: A demoted their own household list back to personal — the column-level UPDATE grant on public.lists is not withholding household_id';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 6 — as B (no household), creating a list scoped to someone else's
+-- household must fail the INSERT `with check`.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000000b","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.lists (owner_id, household_id, name)
+    values ('00000000-0000-4000-8000-00000000000b',
+            '10000000-0000-4000-8000-000000000001',
+            'B smuggling a list into A''s household');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: B (no household) created a list inside A''s household — the INSERT with check is not scoping household_id to the caller''s own household';
+  end if;
+end $$;
+
+reset role;
+
+rollback;


### PR DESCRIPTION
Closes #2.

## What shipped

Personal and household grocery lists with full CRUD, freeform manual ordering, and check-off — the vertical slice defined in `03-SPEC.md` § Slice 2.

- `lists` / `list_items` schema, RLS policies, and a promote-to-household RPC (`84d01ff`)
- Fractional base-62 order keys (`collate "C"`, no `digits` override — see HANDOFF for why both are load-bearing) and the lists client library (`f82b04c`)
- List surfaces wired into the shared UI (`76c351b`)
- Lists and items screens: create, edit, remove, check off, reorder via move up/down (`1affe1d`)
- React Navigation adopted ahead of this feature work, since Lists — not the household screen — is now the home screen for everyone, paired or not

Key scope decisions agreed at Step 2 (full reasoning in the issue and `03-SPEC.md`):
- Scope is `household_id` alone, no separate `type` column
- Read policy uses `=`, not `is not distinct from` — otherwise every householdless user would see every other householdless user's personal lists
- Personal → household promotion only; no demotion path (the want behind "make personal again" is *copy*, which is Slice 9)
- Soft delete on both tables — Supabase RLS doesn't apply to `DELETE`, so hard deletes would broadcast to every subscriber regardless of household
- Writes go direct-to-table under RLS; only promotion is an RPC (Slice 1's write-through-RPC rule exists for invariants RLS can't express atomically, and this slice has none besides promotion)

Item quantities were raised at Step 2 and deliberately left out of scope (logged in `CHANGE-LOG.md`).

## How it was verified

All ten checklist items in #2 verified live on the deployed preview,
https://cartel-git-slice-2-lists-items-mp3anthonys-projects.vercel.app,
across two genuinely independent anonymous sessions (distinct `auth.uid()`s
confirmed, not just two tabs of one browser profile — the first attempt at
this used two tabs and proved nothing, since `localStorage` is shared
per-origin). One session ran in this repo's own Browser pane, the other in a
separate Chrome profile.

Covered: personal list create/reload/reorder/check/remove/rename survives a
cold reload of a deep link; a fresh anonymous user with no household lands on
Lists and can build one; two such users are mutually invisible; household
pairing by invite code; a household list is visible to a paired member after
reload while a personal one stays invisible; promotion runs through a real
in-place confirm (not a native `Alert`, which is a no-op on
`react-native-web`) and the promoted list appears to the other member after
reload; no demotion control exists anywhere in the UI.

`npx expo export --platform web` (the exact Vercel build command) re-run
clean against the branch tip just before opening this PR.

Native (iOS/Android) has still never been run — tracked on #10 and #1, not a
regression introduced here.

## Known gaps carried forward (not blocking)

- `renameList`/`removeList` exist in `mobile/src/lib/lists.ts` but aren't
  wired to any screen — issue #2's checklist never needed list-level
  rename/delete.
- `PrimaryButton`'s missing `aria-busy` on web (task chip already filed).
- `CHANGE-LOG.md` pending items: captcha on anonymous sign-in, orphaned
  households after member removal, item quantities.
