### PR TITLE
Slice 3 — Real-Time Household Sync

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,28 +5,34 @@
 
 ## Last active
 
-- Ticket / spec section: 03-SPEC.md § Slice 2, filed as issue #2. **Merged to
-  `main`** via PR #12 (merge commit `685b668`, 2026-08-10).
-  https://github.com/mp3anthony/cartel/pull/12
-- Status: before merging, a final code-review pass ran the `code-review` skill
-  (Standards + Spec axes, parallel sub-agents) against the merge-base. Spec axis
-  came back clean — both priority checks (no RLS SELECT policy references
-  `deleted_at`; `digits` never passed to `generateKeyBetween`) verified by grep,
-  not eyeballed. Standards axis found three non-blocking judgement calls (no
-  repo standards doc exists, so these are Fowler-baseline smells, not rule
-  violations): duplicated write-wrapping boilerplate in `mobile/src/lib/lists.ts`
-  (six functions, same shape), `ListsScreen.submit()` re-inlining the
-  busy/error/write/refresh sequence that `ListDetailScreen`'s `mutate()` helper
-  already named and solved, and `mobile/src/lib/household.ts` picking up
-  list-domain error codes it wasn't originally scoped for. None acted on —
-  left as an easy follow-up, not urgent enough to hold the merge.
-- All ten of issue #2's checklist items verified live pre-merge, across two
-  genuinely independent anonymous sessions (see the Traps entry on browser tabs
-  below — the first attempt at this used two tabs and proved nothing). Native
-  never run, as always. Preview URL (now superseded by `main`, kept for
-  reference): https://cartel-git-slice-2-lists-items-mp3anthonys-projects.vercel.app
-- Next step: **Slice 3 (#3, Real-Time Household Sync)** starts at Protocol
-  Step 2. Expect its "no open questions" label to be wrong too — check first.
+- Ticket / spec section: 03-SPEC.md § Slice 3, filed as issue #3. **PR #13 open**
+  on branch `slice-3-realtime-sync`, not yet merged.
+  https://github.com/mp3anthony/cartel/pull/13
+- Status: Step 2 widened the issue's scope before any planning started — the
+  original "no open questions" label only covered item-level sync (matching the
+  literal acceptance test); agreed to also cover list-index-level sync (a list
+  created/renamed/removed/promoted by another member updates the lists home
+  screen live too), since leaving that screen on manual-refresh right next to a
+  live-updating list would have been an inconsistent UX the CRD's own "real-time
+  sync across household members" language doesn't support. Issue #3 was edited
+  to record the widened scope and its testing checklist before Planner ran.
+- All three of issue #3's checklist items verified live pre-merge, across two
+  genuinely independent anonymous sessions (Browser pane + Claude-in-Chrome,
+  `auth.uid()`s confirmed to differ first). Item-level add and check-off tested
+  both directions; list-index create, promote, rename and soft-delete all
+  confirmed propagating live with no manual refresh. Rename and soft-delete were
+  triggered with a direct `execute_sql` UPDATE rather than through the app —
+  neither has a UI path (see Loose ends) — which incidentally is a stronger test
+  of the underlying mechanism than clicking a button would have been, since it
+  proves Realtime delivers the event regardless of which client (or no client)
+  performed the write. Native never run, as always. No code-review pass yet —
+  that normally happens before merge, same as Slice 2, and hasn't run this
+  session. Preview URL:
+  https://cartel-git-slice-3-realtime-sync-mp3anthonys-projects.vercel.app
+- Next step: run the `code-review` skill against the merge-base, then merge
+  #13. After that, **Slice 4 (#4, Locations)** is currently labelled
+  ready-for-human (design reference was missing) — check whether that block is
+  actually lifted before trusting the label either way.
 
 ## Notes for next session
 
@@ -40,90 +46,88 @@
   own auth — use the Vercel MCP's `get_access_to_vercel_url` for a 23-hour
   shareable link rather than assuming a bare preview URL loads.
 - Repo was recreated fresh; old sync-engine history was deliberately left behind.
-  Local branch `main` held that abandoned history until this session, when merging
-  PR #12 forced a real touch of `main` and it got repaired (`git branch -f main
-  origin/main`) instead of deleted. If a checkout elsewhere still has the old
-  local `main`, the same fix applies — `origin/main` was always the real one.
+  `origin/main` is always the real `main` if a stale local branch ever disagrees.
 
 **Decisions that will look like mistakes if you don't know why**
+- **Realtime is enabled per-table via publication membership, not per-row.**
+  Migration `20260810000004` adds `lists`/`list_items` to the `supabase_realtime`
+  publication — Slice 2 already wrote both tables' RLS with Realtime's
+  authorization model in mind, but never actually switched it on. A table absent
+  from that publication emits no `postgres_changes` events no matter what the
+  client subscribes to; this was true and silent from Slice 2 until this slice.
+- **`useLists`' subscription is unfiltered; `useListItems`' is filtered on
+  `list_id`.** A user's visible `lists` rows are `owner = me OR household =
+  mine` — one `postgres_changes` filter is a single equality expression and
+  can't express that OR, so the index subscription relies on RLS alone to scope
+  what arrives, same philosophy `loadLists()` already used for the query itself.
+  `list_items` has no such OR (a `ListDetailScreen` is always exactly one list),
+  so it filters. Don't "fix" the index subscription to match the item one — the
+  asymmetry is deliberate, not an inconsistency.
+- **No optimistic reconciliation, still.** A `postgres_changes` event just calls
+  the hook's existing `refresh()` — the same full reload a manual write already
+  triggers. A write on the writer's own device can now double-refresh (once from
+  its own post-write call, once from the echoed event); harmless, not suppressed.
 - **React Navigation, adopted as its own commit ahead of Slice 2's feature work.**
-  Lists is the home screen for everyone now, household-or-not — Slice 1's "the
-  household screen is the whole app until you pair" could not survive Slice 2's own
-  acceptance test. The household is a route reached from the header, registered as
-  one screen or the other but never both, so the type system rules out landing on
-  a household screen with no household to show.
+  Lists is the home screen for everyone now, household-or-not — the household is
+  a route reached from the header, registered as one screen or the other but
+  never both.
 - **`lists`/`list_items` are written direct-to-table under RLS**, not through
-  RPCs — a deliberate departure from Slice 1's rule. That rule exists for
-  invariants RLS can't express atomically; Slice 2 has none except promotion,
-  which kept its RPC. Don't silently extend the direct-write pattern to a future
-  slice that *does* have an atomicity invariant — re-derive it, don't copy it.
-- **No demotion function, and none should get added.** The want behind "make this
-  personal again" is *copy*, which is Slice 9's job. Enforced by a withheld
-  column-level UPDATE grant on `household_id`, not a trigger — grep for a trigger
-  here and you'll find nothing and wrongly conclude it's unenforced.
+  RPCs, except promotion. Don't silently extend the direct-write pattern to a
+  future slice that *does* have an atomicity invariant — re-derive it, don't
+  copy it.
+- **No demotion function, and none should get added.** The want behind "make
+  this personal again" is *copy*, which is Slice 9's job. Enforced by a
+  withheld column-level UPDATE grant on `household_id`, not a trigger.
 - **`position` is `collate "C"`, and `fractional-indexing`'s `digits` argument is
-  never passed, anywhere.** Both are measured, not stylistic: this database sorts
-  `'a1' < 'A1'` under its default ICU collation, byte order says the opposite, and
-  base-62 keys only sort correctly under byte order. Separately, the package's
-  *value* digits default to base 62 but its *integer-head* alphabet defaults to
-  base 52 only when `digits` is omitted — passing it explicitly to "be consistent"
-  produces an incompatible keyspace and corrupts existing ordering against new
-  keys. `03-SPEC.md` § Slice 2 has the full mechanism.
-- `renameList`/`removeList` exist in `mobile/src/lib/lists.ts` and are **not**
-  wired to any screen — issue #2's checklist never needed list-level rename/delete,
-  so no UI was built for it. Known dead code, not an oversight.
+  never passed, anywhere.** This database sorts `'a1' < 'A1'` under its default
+  ICU collation; base-62 keys only sort correctly under byte order. `03-SPEC.md`
+  § Slice 2 has the full mechanism.
 
 **Traps**
 - RLS policy expressions run as the *querying* user. Revoking a policy-helper
   function's EXECUTE from `authenticated` silently breaks every read while writes
-  keep working — creating a row succeeds and reading it back throws. Cost an hour
-  in Slice 1; see migration `20260810000002` (whose own header comment pointed at
-  the wrong file until this slice fixed it — the revoke is in `20260810000000`).
+  keep working. See migration `20260810000002`.
 - **A soft-delete policy must never reference `deleted_at`.** Realtime authorises
   each event against the subscriber's SELECT policy evaluated on the *new* row, so
   a policy saying `deleted_at is null` would suppress the very UPDATE that performs
-  the deletion — other members would never see a removal. Filtering `deleted_at` is
-  the client query's job, always. Getting this backwards is invisible until Slice 3
-  actually has two live subscribers.
+  the deletion. This was a theoretical risk recorded in Slice 2 and a live-verified
+  fact as of Slice 3 — the soft-delete UPDATE was confirmed arriving over both
+  sessions' subscriptions before the client-side filter hid the row.
 - **Two tabs of one browser profile are the same user.** `localStorage` is shared
-  per-origin, not per-tab — the anonymous session lives there, so two tabs prove
-  nothing about cross-household visibility. Confirmed by accident this session:
-  clearing one pane tab's storage to force a second identity silently clobbered the
-  *other* tab's session too, because they were never independent. Genuine
-  two-session verification needs two separate browser profiles (this session used
-  the in-app Browser pane for one and Claude-in-Chrome for the other), confirmed by
-  checking the two sessions' `auth.uid()`s actually differ before trusting the test.
+  per-origin, not per-tab. Genuine two-session verification needs two separate
+  browser profiles (Browser pane + Claude-in-Chrome), confirmed by checking the
+  two sessions' `auth.uid()`s actually differ before trusting the test.
 - `react-native-web` 0.21 does not map `accessibilityState.checked` (or `.busy`) to
-  the DOM's `aria-checked`/`aria-busy`. `CheckTarget` in `ui.tsx` carries both an
-  explicit `aria-checked` prop and `accessibilityState` for this reason — without
-  it the control announced `role="checkbox"` with no state at all, worse than no
-  role. `PrimaryButton` has the equivalent gap for `aria-busy`, not yet fixed — a
-  task chip was filed for it.
-- Android and iOS have **never been run**, and that is recorded on #10 and #1
-  rather than implied to pass. The Vercel link is the agreed review surface for
-  the client and their testers; Expo Go was considered and rejected as day-to-day
-  workflow. Treat native-only breakage as expected-but-undiscovered, not a
-  regression.
+  the DOM's `aria-checked`/`aria-busy`. `CheckTarget` in `ui.tsx` carries both for
+  this reason. `PrimaryButton`'s `aria-busy` gap is still open (task chip filed).
+- Android and iOS have **never been run** (#10, #1). The Vercel link is the
+  agreed review surface. Treat native-only breakage as expected-but-undiscovered.
 - Test users are anonymous rows in `auth.users` with `is_anonymous = true`. Reset
   between runs with
   `delete from public.households; delete from auth.users where is_anonymous = true;`
-  — this now also cascades `public.lists` and `public.list_items`.
-- There is still no test harness beyond `supabase/tests/rls_lists.sql` (SQL-level
-  RLS assertions only, run via the Supabase MCP's `execute_sql` against the hosted
-  project — there is no local CLI, no `config.toml`, no Docker). That tool commits
-  each call in its own transaction regardless of an open `begin`, so state never
-  survives between separate `execute_sql` calls; a multi-statement script in one
-  call is fine, chaining state across calls is not.
+  — cascades `public.lists` and `public.list_items`. Done at the end of this
+  session; stale rows from a prior session's testing were also found and cleared
+  at the *start* of this one — always check before assuming a clean slate.
+- There is still no test harness beyond SQL run via the Supabase MCP's
+  `execute_sql` against the hosted project (no local CLI, no `config.toml`, no
+  Docker). Each call commits in its own transaction regardless of an open
+  `begin` — a multi-statement script in one call is fine, chaining state across
+  calls is not. `supabase/tests/realtime_lists.sql` (new this slice) checks
+  publication membership only — it cannot and does not test that events arrive
+  over a live socket; that's the manual two-session check.
 
 **Loose ends**
 - Palette is locked (burnt orange `#C2410C`) with measured contrast ratios in
   `mobile/src/theme/tokens.ts` — that file is the source of truth, not the design
   doc.
-- #4 (location merge UX) and #7 (route-learning heuristic) were labelled
-  ready-for-human because the design reference was missing. That block is lifted —
-  re-check whether they can move to ready-for-agent.
+- `renameList`/`removeList` in `mobile/src/lib/lists.ts` are still **not** wired
+  to any screen. Slice 3 exercised both directly against the database to test
+  Realtime propagation (see Last active) — that is not the same as them being
+  reachable from the app, and still isn't an oversight to silently fix.
+- #7 (route-learning heuristic) was labelled ready-for-human because the design
+  reference was missing — unchecked this session, still worth re-checking before
+  trusting the label.
 - `CHANGE-LOG.md` has three pending items, none built: captcha on anonymous
-  sign-in, orphaned households after member removal, and item quantities
-  (raised at Slice 2 Step 2, deliberately left out of that slice).
+  sign-in, orphaned households after member removal, and item quantities.
 - `PrimaryButton`'s missing `aria-busy` (see Traps) has an open task chip.
 - CLAUDE.md's "## Rules" section still has placeholder bullets.

--- a/mobile/src/hooks/useListItems.ts
+++ b/mobile/src/hooks/useListItems.ts
@@ -56,5 +56,44 @@ export function useListItems(client: SupabaseClient, listId: string) {
     refresh();
   }, [refresh]);
 
+  useEffect(() => {
+    // Unlike `useLists`'s index-wide subscription, this one *can* filter on the
+    // server: this hook is already scoped to exactly one list id, so there's no OR of
+    // ownership and household membership to lose by narrowing the subscription to
+    // `list_id=eq.${listId}` — it's the same scoping the `.eq('list_id', listId)` in
+    // `loadItems()` already does, not a second, less-trustworthy copy of it.
+    //
+    // No `enabled` gate, for the same reason the load effect above has none: this
+    // hook is only ever mounted by a screen the navigator renders, which is already
+    // past the session gate its parent holds.
+    //
+    // Keyed on `listId` (via the channel name and the dependency array) rather than
+    // mounted once like `useLists`'s subscription: this hook itself remounts fresh
+    // per screen instance, and its channel must tear down and resubscribe whenever
+    // the screen switches to a different list, not stay attached to the one it first
+    // subscribed to.
+    //
+    // Current navigation never pushes a second `ListDetail` instance for the same
+    // listId — nothing in this screen navigates to itself — so two subscriptions
+    // colliding on the same channel name `list-items:<id>` is not reachable today.
+    // Left undefended rather than solved: if it ever became reachable, two
+    // identically-named channel subscriptions would have version-inconsistent
+    // supabase-js behaviour, but there is nothing to design against yet.
+    const channel = client
+      .channel(`list-items:${listId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'list_items', filter: `list_id=eq.${listId}` },
+        () => {
+          void refresh();
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void client.removeChannel(channel);
+    };
+  }, [client, listId, refresh]);
+
   return { view, refresh };
 }

--- a/mobile/src/hooks/useLists.ts
+++ b/mobile/src/hooks/useLists.ts
@@ -9,12 +9,17 @@ export type ListsView =
   | { status: 'error'; message: string };
 
 /**
- * The list index, loaded once and reloaded after every write.
+ * The list index, loaded once, reloaded after every write, and reloaded again
+ * whenever a `postgres_changes` event says some other device changed a row.
  *
  * There are no optimistic updates here or anywhere in this slice: a mutation writes,
  * then calls `refresh`. Guessing at the result would mean two sources of truth for
- * the same rows, and Slice 3's live subscription is the point at which reconciling
- * them becomes a coherent thing to design rather than a shortcut.
+ * the same rows. The live subscription below doesn't change that — it calls the same
+ * `refresh` a manual write does, so there is still exactly one way this hook's state
+ * gets set: a fresh SELECT. A write on the writer's own device can now trigger two
+ * back-to-back refreshes — one from its own post-write call, one from the echo of
+ * that same write arriving over the subscription — which is redundant but harmless,
+ * not something worth suppressing.
  *
  * Unlike `useHousehold` this one guards against landing on an unmounted screen.
  * `refresh` is called after every add, rename, check, move and remove, so a response
@@ -55,6 +60,46 @@ export function useLists(client: SupabaseClient, enabled: boolean) {
       refresh();
     }
   }, [enabled, refresh]);
+
+  useEffect(() => {
+    // Same `enabled` gate as the load effect above, and for the same reason: nothing
+    // useful can be subscribed to before there's a session to be signed in as.
+    if (!enabled) {
+      return;
+    }
+
+    // No filter on this subscription, deliberately, and for the same reason
+    // `loadLists()` adds none to its query: a user's visible rows are `owner_id = me
+    // OR household_id = my_household`, and a `postgres_changes` filter is a single
+    // `column=eq.value` expression — it cannot express that OR. Subscribing
+    // unfiltered and letting RLS do the authorizing (as described in migration
+    // 20260810000004) is the only shape available; adding a filter here would wrongly
+    // imply this query is trusted to do its own scoping.
+    //
+    // `event: '*'` rather than listing `INSERT` and `UPDATE` separately: there is no
+    // DELETE grant on `lists` (removal is a soft-delete UPDATE, same as everywhere
+    // else in this slice), so today the two are equivalent. `'*'` just means this
+    // subscription doesn't need revisiting if that ever stops being true.
+    //
+    // promote_to_household() fires this with no special-casing needed. It's an RPC
+    // from the client's point of view, but underneath it's a plain `UPDATE
+    // public.lists`, so it's logged to WAL and delivered like any other change — the
+    // household member who didn't run the promotion still sees the list arrive.
+    //
+    // The fixed channel name 'lists-index' is safe to leave unparameterized because
+    // this hook is mounted exactly once for the app's whole lifetime, in App.tsx's
+    // `Bootstrapped` — there is no second instance it could collide with.
+    const channel = client
+      .channel('lists-index')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'lists' }, () => {
+        void refresh();
+      })
+      .subscribe();
+
+    return () => {
+      void client.removeChannel(channel);
+    };
+  }, [client, enabled, refresh]);
 
   return { view, refresh };
 }

--- a/supabase/migrations/20260810000004_realtime_lists_and_items.sql
+++ b/supabase/migrations/20260810000004_realtime_lists_and_items.sql
@@ -1,0 +1,35 @@
+-- Slice 3 — Real-Time Household Sync.
+--
+-- Adds `public.lists` and `public.list_items` to the `supabase_realtime`
+-- publication. Verified via `pg_publication_tables` before writing this migration
+-- that the publication currently has zero tables in it — Slice 2 shipped both
+-- tables' RLS policies with Realtime's authorization model already in mind (see
+-- the header of 20260810000003), but never actually turned Realtime on for them.
+-- A table absent from this publication never emits `postgres_changes` events no
+-- matter what the client subscribes to; the subscription code added in this slice
+-- would otherwise sit there silently doing nothing.
+--
+-- Authorization model: this project uses the default `postgres_changes` model,
+-- not `realtime.messages` broadcast authorization. Each change is authorized
+-- per-subscriber against the table's existing SELECT policy, evaluated against
+-- the row's *new* values — there is no separate Realtime-specific grant or
+-- channel-authorization function to write. Publication membership is the whole
+-- of what this migration needs to do.
+--
+-- Reaffirmed, not touched: neither `lists_select_visible` nor
+-- `list_items_select_visible` may ever reference `deleted_at`. Realtime
+-- authorizes UPDATEs — which is what a soft delete is — against the new row, so
+-- a policy saying `deleted_at is null` would suppress the very event that
+-- performs the deletion, and other household members would never see a removal
+-- arrive. Filtering `deleted_at` stays the client query's job, as it already was
+-- before this migration.
+--
+-- Replica identity is deliberately left at its default (`d`, primary-key only)
+-- rather than raised to `FULL`. `FULL` only changes what *old*-row data ships on
+-- UPDATE/DELETE payloads; the *new* row always ships in full regardless, and
+-- that's all either client handler uses — both call `refresh()`, a fresh SELECT,
+-- rather than reading the payload itself. There is also no DELETE policy or
+-- grant on either table (removal is a soft-delete UPDATE, per 20260810000003),
+-- so DELETE's old-row behaviour is moot here anyway.
+
+alter publication supabase_realtime add table public.lists, public.list_items;

--- a/supabase/tests/realtime_lists.sql
+++ b/supabase/tests/realtime_lists.sql
@@ -1,0 +1,21 @@
+-- Confirms lists/list_items are members of supabase_realtime after migration
+-- 20260810000004. This does not and cannot test that events actually arrive over a
+-- socket — that's the live two-session check. It only catches a migration that
+-- silently targeted the wrong publication/schema/table name.
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'lists'
+  ) then
+    raise exception 'FAIL: public.lists is not in the supabase_realtime publication';
+  end if;
+
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'list_items'
+  ) then
+    raise exception 'FAIL: public.list_items is not in the supabase_realtime publication';
+  end if;
+end $$;


### PR DESCRIPTION
Closes #3.

## What
Turns on Supabase Realtime for `lists`/`list_items` (added to the
`supabase_realtime` publication — it was never actually enabled despite Slice
2's RLS policies already being written with Realtime's authorization model in
mind) and subscribes both `useLists` and `useListItems` to it. Both layers
agreed in issue #3's Step 2 discussion:

- **Item-level**: `useListItems` subscribes filtered to the open list's id;
  add/edit/check/reorder/remove by another member calls the existing
  `refresh()`.
- **List-index level**: `useLists` subscribes unfiltered (RLS scopes what's
  delivered — same philosophy `loadLists()` already uses); a list
  created/renamed/removed/promoted by another member calls the existing
  `refresh()`.

No optimistic reconciliation — both handlers just call the hook's existing
`refresh()`, same single source of truth the write path already used.

## Testing checklist (from #3)
- [ ] Two household members with the same household list open see an item edit on one device appear on the other within a few seconds, no manual refresh
- [ ] A list created, renamed, removed, or promoted to the household by one member appears/updates/disappears on another member's lists home screen without navigating away and back
- [ ] Confirmed personal lists never propagate to anyone but their owner, at either the item or list-index level

## Verified pre-merge
- Migration applied to hosted project `chacavfoewyiwrfgvxtj`; publication membership confirmed via `supabase/tests/realtime_lists.sql`.
- `supabase/tests/rls_lists.sql` re-run unchanged — no regression to Slice 2's policies.
- `npx tsc --noEmit` clean.
- Live two-session verification pending (Orchestrator, this session — same two-separate-browser-profile method as Slice 2, not two tabs of one).