### PR TITLE
Wire list rename/remove to the UI

### DIFF
--- a/mobile/src/screens/ListDetailScreen.tsx
+++ b/mobile/src/screens/ListDetailScreen.tsx
@@ -25,7 +25,9 @@ import {
   moveItem,
   promoteList,
   removeItem,
+  removeList,
   renameItem,
+  renameList,
   setChecked,
   type ListItemRow,
 } from '../lib/lists';
@@ -65,7 +67,10 @@ export function ListDetailScreen({
   const [draft, setDraft] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState('');
+  const [renamingList, setRenamingList] = useState(false);
+  const [listNameDraft, setListNameDraft] = useState('');
   const [confirmingShare, setConfirmingShare] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -177,6 +182,45 @@ export function ListDetailScreen({
         // settles both.
         await onListsChanged();
         setConfirmingShare(false);
+      },
+    );
+  }
+
+  function startRenameList() {
+    if (!list) {
+      return;
+    }
+
+    setError(null);
+    setListNameDraft(list.name);
+    setRenamingList(true);
+  }
+
+  function commitRenameList() {
+    if (listNameDraft.trim().length === 0) {
+      return;
+    }
+
+    // Same reasoning as share(): the name lives on the list row the index loaded,
+    // not on anything useListItems reloads, so the header and the Lists screen
+    // behind it both need that index reloaded to agree with the database.
+    void mutate(
+      () => renameList(client, listId, listNameDraft),
+      async () => {
+        await onListsChanged();
+        setRenamingList(false);
+      },
+    );
+  }
+
+  function removeListNow() {
+    void mutate(
+      () => removeList(client, listId),
+      async () => {
+        // A removed list has nothing left on this screen to show — reload the index
+        // so it drops out there too, and leave for the one that still does.
+        await onListsChanged();
+        navigation.navigate('Lists');
       },
     );
   }
@@ -319,6 +363,57 @@ export function ListDetailScreen({
             }
           />
         ),
+      )}
+
+      {renamingList ? (
+        <View style={styles.editor}>
+          <Field
+            label="List name"
+            value={listNameDraft}
+            onChangeText={setListNameDraft}
+            autoCapitalize="sentences"
+            autoFocus
+            maxLength={60}
+            editable={!busy}
+            onSubmitEditing={commitRenameList}
+            returnKeyType="done"
+          />
+          <SecondaryButton
+            label="Save"
+            onPress={commitRenameList}
+            disabled={busy || listNameDraft.trim().length === 0}
+          />
+          <SecondaryButton
+            label="Cancel"
+            onPress={() => setRenamingList(false)}
+            disabled={busy}
+          />
+        </View>
+      ) : (
+        <SecondaryButton
+          label="Rename list"
+          onPress={startRenameList}
+          disabled={busy}
+        />
+      )}
+
+      {confirmingRemove ? (
+        <Confirm
+          message="Removing this list takes it off your Lists screen for good, along with everything on it. This can’t be undone."
+          confirmLabel="Remove list"
+          onConfirm={removeListNow}
+          onCancel={() => setConfirmingRemove(false)}
+          busy={busy}
+        />
+      ) : (
+        <SecondaryButton
+          label="Remove list"
+          onPress={() => {
+            setError(null);
+            setConfirmingRemove(true);
+          }}
+          disabled={busy}
+        />
       )}
 
       {canShare && confirmingShare ? (


### PR DESCRIPTION
## What

`renameList`/`removeList` already existed in `mobile/src/lib/lists.ts` (written and tested during Slice 3, to verify Realtime propagation) but were unreachable from any screen. Adds **Rename list** and **Remove list** to `ListDetailScreen`, reusing:

- the screen's existing `mutate()` plumbing (busy → clear error → write → reload)
- the `Field` + Save/Cancel inline-editor pattern already used for item rename
- the `Confirm` pattern already used for "Share with household"

## Why now, and why no issue

Not scoped under any open Slice issue — this was an open task chip and a `HANDOFF.md` loose end left by Slice 3's code review ("its own acceptance test can't be reproduced by a human clicking through the app"). Confirmed with the user to go straight to a PR rather than filing one first, given the small single-file diff reusing an already-shipped pattern.

## Notes

- **Rename** reloads the lists index (`onListsChanged`) the same way `share()` does — the name lives on the row the index loaded, not on anything `useListItems` reloads, so without it the header and the Lists screen behind it would disagree with the database.
- **Remove** does the same reload before navigating back to `Lists`, since a removed list has nothing left on this screen to show.
- No client-side permission gating on either button — same as the existing item rename/remove — the RLS `using` clause and column grants are what actually decide whether the write is allowed; the client just calls and shows whatever error comes back.

## Testing checklist

- [x] `tsc --noEmit` passes
- [x] Verified live against the local dev server: created a list, renamed it (header and Lists index both updated live), then removed it (list dropped from the index, screen navigated back to Lists)
- [x] No console warnings beyond pre-existing framework noise unrelated to this change
- [ ] Native (iOS/Android) — never run, as always; Vercel preview is the agreed review surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
