### PR TITLE
Slice 4 — Locations (Supermarkets)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -20,6 +20,7 @@ import { HouseholdScreen } from './src/screens/HouseholdScreen';
 import { HouseholdSetupScreen } from './src/screens/HouseholdSetupScreen';
 import { ListDetailScreen } from './src/screens/ListDetailScreen';
 import { ListsScreen } from './src/screens/ListsScreen';
+import { LocationsScreen } from './src/screens/LocationsScreen';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import type { Tokens } from './src/theme/tokens';
 
@@ -50,6 +51,7 @@ const linking: LinkingOptions<RootStackParamList> = {
       ListDetail: 'list/:listId',
       HouseholdSetup: 'household/setup',
       Household: 'household',
+      Locations: 'locations',
     },
   },
 };
@@ -160,6 +162,10 @@ function Bootstrapped({ env }: { env: Env }) {
               inHousehold={state.status === 'member'}
             />
           )}
+        </Stack.Screen>
+
+        <Stack.Screen name="Locations" options={{ title: 'Locations' }}>
+          {(props) => <LocationsScreen {...props} client={client} />}
         </Stack.Screen>
 
         {state.status === 'none' ? (

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -22,6 +22,14 @@
     "web": {
       "favicon": "./assets/favicon.png",
       "output": "single"
-    }
+    },
+    "plugins": [
+      [
+        "expo-location",
+        {
+          "locationWhenInUsePermission": "Cartel uses your location to check whether the supermarket you're adding already exists, so it isn't listed twice."
+        }
+      ]
+    ]
   }
 }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native-stack": "^7.18.8",
         "@supabase/supabase-js": "^2.112.2",
         "expo": "~57.0.11",
+        "expo-location": "~57.0.9",
         "expo-status-bar": "~57.0.1",
         "fractional-indexing": "^4.0.0",
         "react": "19.2.3",
@@ -2951,6 +2952,18 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "57.0.9",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-57.0.9.tgz",
+      "integrity": "sha512-NfTBIgpHDagevd8gz3zSU2dcA+2KjDZPsK8/A57BPKeApcgFzh44QpzYDgSOc01sLNa3DxIsgQSWdSXXpj7IXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.11.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "@react-navigation/native-stack": "^7.18.8",
     "@supabase/supabase-js": "^2.112.2",
     "expo": "~57.0.11",
+    "expo-location": "~57.0.9",
     "expo-status-bar": "~57.0.1",
     "fractional-indexing": "^4.0.0",
     "react": "19.2.3",

--- a/mobile/src/hooks/useLocations.ts
+++ b/mobile/src/hooks/useLocations.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { loadLocations, type LocationRow } from '../lib/locations';
+
+export type LocationsView =
+  | { status: 'loading' }
+  | { status: 'loaded'; locations: LocationRow[] }
+  | { status: 'error'; message: string };
+
+/**
+ * The full `locations` index, load-on-mount.
+ *
+ * No `enabled` flag: like `useListItems`, this hook is only ever mounted by a screen
+ * the navigator renders, which is already past the session gate its parent holds —
+ * unlike `useHousehold`, which is reached pre-navigator and genuinely needs to wait.
+ *
+ * No `postgres_changes` subscription, which is the one deliberate divergence from
+ * `useLists`'s shape: there is no live-sync acceptance test for this slice, so this
+ * hook's load-once behaviour matches `useHousehold`'s rather than `useLists`'s. The
+ * `refresh()` it exposes is how the screen picks up a location it just created.
+ */
+export function useLocations(client: SupabaseClient) {
+  const [view, setView] = useState<LocationsView>({ status: 'loading' });
+  const active = useRef(true);
+
+  // Declared before the loading effect so its cleanup runs first on unmount.
+  useEffect(() => {
+    active.current = true;
+
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const outcome = await loadLocations(client);
+
+    if (!active.current) {
+      return;
+    }
+
+    setView(
+      outcome.ok
+        ? { status: 'loaded', locations: outcome.value }
+        : { status: 'error', message: outcome.message },
+    );
+  }, [client]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { view, refresh };
+}

--- a/mobile/src/lib/geolocation.ts
+++ b/mobile/src/lib/geolocation.ts
@@ -1,0 +1,53 @@
+import * as Location from 'expo-location';
+
+/**
+ * `denied` covers every non-granted permission outcome, including the call itself
+ * throwing (an unsupported browser, for instance) — the caller does not need to
+ * distinguish "the user said no" from "the platform cannot ask", because both lead
+ * to the same sticky screen-level fallback. `error` is a different failure class
+ * entirely: permission was granted and the GPS fetch itself failed, which is worth
+ * its own message rather than being folded into denial.
+ */
+export type LocationPermissionOutcome =
+  | { status: 'granted'; lat: number; lng: number }
+  | { status: 'denied' }
+  | { status: 'error'; message: string };
+
+/**
+ * Requests foreground location permission and, if granted, a single fix.
+ *
+ * No `Platform.OS` branching: `expo-location`'s API is already cross-platform, and
+ * the plan for this module is deliberately to stay that way rather than reaching for
+ * platform-specific behaviour that isn't needed.
+ */
+export async function requestLocation(): Promise<LocationPermissionOutcome> {
+  let permission;
+
+  try {
+    permission = await Location.requestForegroundPermissionsAsync();
+  } catch {
+    return { status: 'denied' };
+  }
+
+  if (permission.status !== 'granted') {
+    return { status: 'denied' };
+  }
+
+  try {
+    const position = await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.Balanced,
+    });
+
+    return {
+      status: 'granted',
+      lat: position.coords.latitude,
+      lng: position.coords.longitude,
+    };
+  } catch {
+    return {
+      status: 'error',
+      message:
+        "Couldn't get your location just now. Check that location services are on, and try again.",
+    };
+  }
+}

--- a/mobile/src/lib/household.ts
+++ b/mobile/src/lib/household.ts
@@ -50,8 +50,13 @@ const MESSAGES: Record<string, string> = {
  * Both the code and the text are checked because the code is the reliable signal when
  * it is present and PostgREST does not always carry one (a network or gateway failure
  * surfaces through the same error shape with no SQLSTATE at all).
+ *
+ * The message stays table-agnostic on purpose: this fallback fires for whichever
+ * table's RLS or column grant the caller tripped, and `locations.ts` (Slice 4) calls
+ * the same `humanise()` — list-specific wording here would be wrong for a locations
+ * denial.
  */
-const DENIED = "You don't have access to that list.";
+const DENIED = "You don't have access to that.";
 
 const DENIAL_TEXT = [
   'violates row-level security policy',

--- a/mobile/src/lib/locations.ts
+++ b/mobile/src/lib/locations.ts
@@ -1,0 +1,133 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { humanise, type Outcome } from './household';
+
+export type LocationRow = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  createdAt: string;
+};
+
+export type NearbyLocation = {
+  id: string;
+  name: string;
+  distanceM: number;
+};
+
+/**
+ * The database's spelling of the row above, kept separate rather than exported so that
+ * snake_case stops at this file. `created_by` is deliberately absent — it is withheld
+ * from the column-level SELECT grant on `public.locations` (see migration
+ * 20260810000005), so selecting it would fail, and nothing in this app reads it back.
+ */
+type LocationRecord = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  created_at: string;
+};
+
+type NearbyLocationRecord = {
+  id: string;
+  name: string;
+  distance_m: number;
+};
+
+/**
+ * The one locked radius value in the app — every caller imports this rather than
+ * re-writing 100. Locked at the tight end of 03-SPEC.md's ~100-150m range for the
+ * merge prompt (see HANDOFF.md, Slice 4 Step 2).
+ */
+export const MERGE_RADIUS_M = 100;
+
+/**
+ * Rounds a metre distance to the nearest 10 for display in the merge prompt. The
+ * underlying `nearby_locations` RPC returns a precise great-circle distance; showing
+ * that precision to a person ("62.3814m away") would read as false accuracy for a
+ * number that is itself only as good as a phone's GPS fix.
+ */
+export function roundToNearest10(metres: number): number {
+  return Math.round(metres / 10) * 10;
+}
+
+export async function loadLocations(client: SupabaseClient): Promise<Outcome<LocationRow[]>> {
+  // RLS grants SELECT on this table to every authenticated user unconditionally —
+  // `public.locations` is deliberately global, unlike `lists`/`list_items` — so no
+  // filter is needed here and none would narrow what comes back.
+  const { data, error } = await client
+    .from('locations')
+    .select('id, name, lat, lng, created_at')
+    .order('name');
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as LocationRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      lat: row.lat,
+      lng: row.lng,
+      createdAt: row.created_at,
+    })),
+  };
+}
+
+export async function findNearbyLocations(
+  client: SupabaseClient,
+  lat: number,
+  lng: number,
+  radiusM: number,
+): Promise<Outcome<NearbyLocation[]>> {
+  const { data, error } = await client.rpc('nearby_locations', {
+    p_lat: lat,
+    p_lng: lng,
+    p_radius_m: radiusM,
+  });
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as NearbyLocationRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      distanceM: row.distance_m,
+    })),
+  };
+}
+
+export async function createLocation(
+  client: SupabaseClient,
+  name: string,
+  lat: number,
+  lng: number,
+): Promise<Outcome<string>> {
+  // `created_by` is left out on purpose. The column defaults to auth.uid(), which is
+  // the same value the insert policy checks it against, so a client that sends it can
+  // only ever agree with the default or be rejected by the policy. One that never
+  // names the column cannot get it wrong. Mirrors createList()'s treatment of
+  // `owner_id` in lists.ts.
+  const { data, error } = await client
+    .from('locations')
+    .insert({ name: name.trim(), lat, lng })
+    .select('id')
+    .single();
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: (data as { id: string }).id };
+}

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -18,4 +18,5 @@ export type RootStackParamList = {
   ListDetail: { listId: string };
   HouseholdSetup: undefined;
   Household: undefined;
+  Locations: undefined;
 };

--- a/mobile/src/screens/ListsScreen.tsx
+++ b/mobile/src/screens/ListsScreen.tsx
@@ -58,20 +58,32 @@ export function ListsScreen({
       // list for the top of the screen, and it is where the destination — a different
       // place, not a mode of this one — belongs.
       headerRight: () => (
-        <Pressable
-          accessibilityRole="button"
-          onPress={() =>
-            household
-              ? navigation.navigate('Household')
-              : navigation.navigate('HouseholdSetup')
-          }
-          style={({ pressed }) => [
-            styles.headerButton,
-            pressed && styles.headerButtonPressed,
-          ]}
-        >
-          <Text style={styles.headerButtonLabel}>Household</Text>
-        </Pressable>
+        <View style={styles.headerButtons}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => navigation.navigate('Locations')}
+            style={({ pressed }) => [
+              styles.headerButton,
+              pressed && styles.headerButtonPressed,
+            ]}
+          >
+            <Text style={styles.headerButtonLabel}>Locations</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() =>
+              household
+                ? navigation.navigate('Household')
+                : navigation.navigate('HouseholdSetup')
+            }
+            style={({ pressed }) => [
+              styles.headerButton,
+              pressed && styles.headerButtonPressed,
+            ]}
+          >
+            <Text style={styles.headerButtonLabel}>Household</Text>
+          </Pressable>
+        </View>
       ),
     });
   }, [household, navigation, styles]);
@@ -209,6 +221,10 @@ export function ListsScreen({
 function createStyles(tokens: Tokens) {
   return StyleSheet.create({
     composer: {
+      gap: tokens.space.sm,
+    },
+    headerButtons: {
+      flexDirection: 'row',
       gap: tokens.space.sm,
     },
     headerButton: {

--- a/mobile/src/screens/LocationsScreen.tsx
+++ b/mobile/src/screens/LocationsScreen.tsx
@@ -1,0 +1,279 @@
+import { useMemo, useState } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  Badge,
+  Body,
+  Confirm,
+  EmptyState,
+  ErrorNote,
+  Field,
+  NAVIGATOR_EDGES,
+  PrimaryButton,
+  Row,
+  Screen,
+  SecondaryButton,
+} from '../components/ui';
+import { useLocations } from '../hooks/useLocations';
+import { requestLocation } from '../lib/geolocation';
+import {
+  createLocation,
+  findNearbyLocations,
+  MERGE_RADIUS_M,
+  roundToNearest10,
+  type NearbyLocation,
+} from '../lib/locations';
+import type { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../theme/ThemeProvider';
+import type { Tokens } from '../theme/tokens';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Locations'> & {
+  client: SupabaseClient;
+};
+
+/**
+ * The global location index, and the one place a location gets created.
+ *
+ * Hard invariant (03-SPEC.md § 0): this screen never reads, displays, or filters by
+ * `created_by`, household, or any notion of "locations I made" vs "locations others
+ * made". `locations.ts` already withholds `created_by` from the SELECT grant — there
+ * is no ownership concept here to accidentally add.
+ *
+ * `selected` is client-side and ephemeral. Nothing about "which location is
+ * selected" is persisted or sent to the backend; it exists only so a row can show a
+ * "Selected" badge for the rest of this screen's mounted lifetime.
+ *
+ * `permissionDenied` is sticky for the same lifetime, once set. There is no retry
+ * button and no settings deep link this phase — a user who denies location access
+ * falls back to searching the existing index for the rest of this visit.
+ */
+export function LocationsScreen({ client }: Props) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { view, refresh } = useLocations(client);
+
+  const [search, setSearch] = useState('');
+  const [composing, setComposing] = useState(false);
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [permissionDenied, setPermissionDenied] = useState(false);
+  const [nearbyMatch, setNearbyMatch] = useState<NearbyLocation | null>(null);
+  const [selected, setSelected] = useState<{ id: string; name: string } | null>(
+    null,
+  );
+
+  function beginComposing() {
+    setError(null);
+    setName('');
+    setComposing(true);
+  }
+
+  function cancelComposing() {
+    setError(null);
+    setComposing(false);
+  }
+
+  async function submitCreate() {
+    // The button is disabled on an empty name, but the keyboard's return key is not.
+    if (name.trim().length === 0) {
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+
+    const perm = await requestLocation();
+
+    if (perm.status === 'denied') {
+      setBusy(false);
+      setPermissionDenied(true);
+      setComposing(false);
+      return;
+    }
+
+    if (perm.status === 'error') {
+      setBusy(false);
+      setError(perm.message);
+      return;
+    }
+
+    const nearby = await findNearbyLocations(
+      client,
+      perm.lat,
+      perm.lng,
+      MERGE_RADIUS_M,
+    );
+
+    if (!nearby.ok) {
+      setBusy(false);
+      setError(nearby.message);
+      return;
+    }
+
+    if (nearby.value.length > 0) {
+      // Already ordered by distance — the nearest candidate is the one worth
+      // surfacing, and there is only ever room for one merge prompt on screen.
+      setBusy(false);
+      setNearbyMatch(nearby.value[0]);
+      return;
+    }
+
+    const created = await createLocation(client, name, perm.lat, perm.lng);
+
+    if (!created.ok) {
+      setBusy(false);
+      setError(created.message);
+      return;
+    }
+
+    await refresh();
+    setBusy(false);
+    setComposing(false);
+    setSelected({ id: created.value, name: name.trim() });
+    setName('');
+  }
+
+  function confirmMerge() {
+    if (!nearbyMatch) {
+      return;
+    }
+
+    // No write: the nearby location already exists, so "using" it is purely a
+    // client-side selection.
+    setSelected({ id: nearbyMatch.id, name: nearbyMatch.name });
+    setNearbyMatch(null);
+    setComposing(false);
+    setName('');
+  }
+
+  function cancelMerge() {
+    // Leaves `composing` true and `name` intact — the user backed out of this one
+    // match, not out of naming a location.
+    setNearbyMatch(null);
+  }
+
+  if (view.status === 'loading') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ActivityIndicator color={tokens.color.accent} size="large" />
+      </Screen>
+    );
+  }
+
+  if (view.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={view.message} />
+      </Screen>
+    );
+  }
+
+  const locations = view.locations;
+  const query = search.trim().toLowerCase();
+  const filtered = query
+    ? locations.filter((location) => location.name.toLowerCase().includes(query))
+    : locations;
+
+  return (
+    <Screen edges={NAVIGATOR_EDGES} align="top" scroll>
+      <Field
+        label="Search locations"
+        value={search}
+        onChangeText={setSearch}
+        placeholder="Papanui PakNSave"
+        autoCapitalize="none"
+      />
+
+      {filtered.map((location) => (
+        <Row
+          key={location.id}
+          label={location.name}
+          onPress={() => setSelected({ id: location.id, name: location.name })}
+          trailing={
+            location.id === selected?.id ? <Badge label="Selected" /> : undefined
+          }
+        />
+      ))}
+
+      {locations.length > 0 && search.trim().length > 0 && filtered.length === 0 ? (
+        <Body>{`No locations match "${search}".`}</Body>
+      ) : null}
+
+      {!composing && locations.length === 0 ? (
+        permissionDenied ? (
+          <EmptyState
+            heading="No locations yet"
+            body="Create one to get started."
+          />
+        ) : (
+          <EmptyState
+            heading="No locations yet"
+            body="Create one to get started."
+            actionLabel="New location"
+            onAction={beginComposing}
+          />
+        )
+      ) : null}
+
+      {error ? <ErrorNote message={error} /> : null}
+
+      {composing && !nearbyMatch ? (
+        <View style={styles.composer}>
+          <Field
+            label="Location name"
+            value={name}
+            onChangeText={setName}
+            autoCapitalize="sentences"
+            autoFocus
+            maxLength={60}
+            editable={!busy}
+            onSubmitEditing={submitCreate}
+            returnKeyType="done"
+          />
+          <PrimaryButton
+            label="Create"
+            onPress={submitCreate}
+            busy={busy}
+            disabled={name.trim().length === 0}
+          />
+          <SecondaryButton
+            label="Cancel"
+            onPress={cancelComposing}
+            disabled={busy}
+          />
+        </View>
+      ) : null}
+
+      {composing && nearbyMatch !== null ? (
+        <Confirm
+          message={`There's already a location nearby: "${nearbyMatch.name}" (~${roundToNearest10(nearbyMatch.distanceM)}m away). Cartel keeps one location per spot to avoid duplicates.`}
+          confirmLabel="Use this location"
+          onConfirm={confirmMerge}
+          onCancel={cancelMerge}
+        />
+      ) : null}
+
+      {!composing && !permissionDenied && locations.length > 0 ? (
+        <PrimaryButton label="New location" onPress={beginComposing} />
+      ) : null}
+
+      {permissionDenied ? (
+        <Body>
+          Location access isn’t available, so new locations can’t be created this
+          session. Search for an existing one below.
+        </Body>
+      ) : null}
+    </Screen>
+  );
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    composer: {
+      gap: tokens.space.sm,
+    },
+  });
+}

--- a/mobile/src/screens/LocationsScreen.tsx
+++ b/mobile/src/screens/LocationsScreen.tsx
@@ -206,7 +206,7 @@ export function LocationsScreen({ client }: Props) {
         permissionDenied ? (
           <EmptyState
             heading="No locations yet"
-            body="Create one to get started."
+            body="Location access isn’t available, so new locations can’t be created this session."
           />
         ) : (
           <EmptyState
@@ -260,10 +260,10 @@ export function LocationsScreen({ client }: Props) {
         <PrimaryButton label="New location" onPress={beginComposing} />
       ) : null}
 
-      {permissionDenied ? (
+      {permissionDenied && locations.length > 0 ? (
         <Body>
           Location access isn’t available, so new locations can’t be created this
-          session. Search for an existing one below.
+          session. Search for an existing one above.
         </Body>
       ) : null}
     </Screen>

--- a/supabase/migrations/20260810000005_locations.sql
+++ b/supabase/migrations/20260810000005_locations.sql
@@ -1,0 +1,103 @@
+-- Slice 4 — Locations / Supermarkets.
+--
+-- `public.locations` is deliberately global: no household/owner predicate anywhere
+-- in this table's RLS, unlike `lists`/`list_items`. 03-SPEC.md § 0 treats this as a
+-- hard invariant — locations must never share an access-control path with
+-- household-scoped data, because a supermarket's coordinates are not a private
+-- fact about the household that visited it. Anyone authenticated may read every
+-- row and insert new ones; there is no update or delete policy or grant, because
+-- no edit/removal flow is in scope for this slice.
+--
+-- `created_by` is provenance metadata only. It is never selected back to a client
+-- — the column-level SELECT grant below withholds it — so it cannot leak who
+-- created a given location, while still letting the INSERT `with check` pin it to
+-- the caller.
+
+create extension if not exists cube with schema extensions;
+create extension if not exists earthdistance with schema extensions;
+
+create table public.locations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (length(trim(name)) between 1 and 60),
+  lat double precision not null check (lat between -90 and 90),
+  lng double precision not null check (lng between -180 and 180),
+  -- Nullable, on delete set null (NOT lists.owner_id's cascade pattern) — a
+  -- location is shared/global infrastructure; it must not disappear because its
+  -- creator's (possibly anonymous, test-swept) auth.users row later does.
+  -- created_by is provenance metadata only, never read back (see grants below).
+  created_by uuid references auth.users (id) on delete set null default auth.uid(),
+  created_at timestamptz not null default now()
+);
+
+create index locations_earth_idx on public.locations
+  using gist (extensions.ll_to_earth(lat, lng));
+
+alter table public.locations enable row level security;
+
+create policy locations_select_all on public.locations
+  for select to authenticated
+  using (true);
+
+create policy locations_insert_own on public.locations
+  for insert to authenticated
+  with check (created_by = (select auth.uid()));
+
+-- No update, no delete policy or grant. No edit/removal flow is in scope for this
+-- slice.
+
+-- Supabase's default privileges grant ALL on new public-schema tables to anon and
+-- authenticated, so without the blanket revoke the grants below would be additions
+-- to an already-open door rather than the whole of the door. Same reasoning as
+-- migration 20260810000003 applied to `lists`/`list_items`.
+revoke all on table public.locations from anon, authenticated;
+
+grant select (id, name, lat, lng, created_at) on table public.locations to authenticated;
+grant insert on table public.locations to authenticated;
+
+-- Nearby search. This project pins `set search_path = ''` on every function (see
+-- the header of 20260810000000), so every extension call below is schema-qualified
+-- against `extensions` rather than relying on search_path to find it. Parameter
+-- names are prefixed (`p_lat`/`p_lng`/`p_radius_m`) to avoid ambiguity with
+-- `locations.lat`/`locations.lng`.
+--
+-- The bounding-box containment check needs `OPERATOR(extensions.@>)`, not bare
+-- `@>` — with search_path pinned to '', plain `@>` cannot be resolved at all (operator
+-- names, unlike function calls, are not implicitly schema-qualifiable by writing
+-- `extensions.` in front of the left-hand operand) and the migration fails to apply
+-- with "operator does not exist: extensions.cube @> extensions.earth". Verified via
+-- a throwaway `execute_sql` call before writing this into the migration.
+--
+-- No `security definer` — this function only touches columns already globally
+-- SELECT-granted to `authenticated`, so invoker rights are simpler and sufficient.
+create or replace function public.nearby_locations(
+  p_lat double precision,
+  p_lng double precision,
+  p_radius_m double precision
+)
+returns table (id uuid, name text, distance_m double precision)
+language sql
+stable
+set search_path = ''
+as $$
+  select
+    l.id,
+    l.name,
+    extensions.earth_distance(
+      extensions.ll_to_earth(p_lat, p_lng),
+      extensions.ll_to_earth(l.lat, l.lng)
+    ) as distance_m
+  from public.locations l
+  where extensions.earth_box(extensions.ll_to_earth(p_lat, p_lng), p_radius_m)
+          operator(extensions.@>) extensions.ll_to_earth(l.lat, l.lng)
+    and extensions.earth_distance(
+          extensions.ll_to_earth(p_lat, p_lng),
+          extensions.ll_to_earth(l.lat, l.lng)
+        ) <= p_radius_m
+  order by distance_m asc;
+$$;
+
+-- A bare `create function` defaults EXECUTE to PUBLIC, which `anon` inherits — the
+-- same trap 20260810000001 fixed for Slice 1's RPCs. Revoke first, then grant only
+-- to `authenticated`, explicitly.
+revoke execute on function public.nearby_locations(double precision, double precision, double precision) from public, anon;
+grant execute on function public.nearby_locations(double precision, double precision, double precision) to authenticated;

--- a/supabase/tests/rls_locations.sql
+++ b/supabase/tests/rls_locations.sql
@@ -1,0 +1,182 @@
+-- RLS policy tests for public.locations (Slice 4).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- Simpler fixtures than rls_lists.sql: no household needed, because the property
+-- under test does not involve households at all — that is the point. Two anonymous
+-- users, B and C, sharing nothing.
+--
+-- WHAT IT IS REALLY GUARDING. `public.locations` is deliberately global per
+-- 03-SPEC.md § 0: unlike `lists`/`list_items`, there is no household/owner
+-- predicate anywhere in its SELECT policy. Assertion 1 is the *inverse* of
+-- rls_lists.sql's core assertion — where that file proves two householdless users
+-- must NOT see each other's lists, this file proves two users sharing nothing
+-- (not even a household) MUST still see each other's locations. That is the one
+-- assertion that actually proves "global" rather than merely "not broken".
+--
+-- Fixtures are the premise, not the thing under test, so the two test users are
+-- inserted as the owning role, which bypasses RLS. Only the assertions run as
+-- `authenticated`. `request.jwt.claims` must be set *before* the role switch:
+-- after it, the session no longer has the privilege to set the GUC on some
+-- configurations, and auth.uid() reads that GUC.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. B and C share nothing — no household, no prior relationship.
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-0000000000b1', true),  -- B
+  ('00000000-0000-4000-8000-0000000000c1', true);  -- C
+
+insert into public.locations (id, name, lat, lng, created_by) values
+  ('40000000-0000-4000-8000-000000000001',
+   'B''s Corner Store', -33.8688, 151.2093,
+   '00000000-0000-4000-8000-0000000000b1');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control, as B.
+-- Without this, the "must be visible" assertions below would prove nothing if the
+-- policy hid everything, including from the creator.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000b1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.locations
+      where id = '40000000-0000-4000-8000-000000000001') <> 1 then
+    raise exception 'FAIL: B cannot see the location B just created';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — THE core property. As C, who shares no household with B and did
+-- not create the row: the location must still be visible. This is the inverse of
+-- rls_lists.sql's null=null assertion — there, no shared context means invisible;
+-- here, no shared context is irrelevant, because locations have no access-control
+-- path through households or ownership at all.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000c1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.locations
+      where id = '40000000-0000-4000-8000-000000000001') <> 1 then
+    raise exception 'FAIL: C cannot see B''s location — locations is not actually global (it is scoping visibility by creator or household when it must not)';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 2 — withheld column. As B, even as the row's own creator,
+-- `created_by` is not selectable. The column-level SELECT grant on
+-- public.locations names id, name, lat, lng, created_at only.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000b1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    perform created_by from public.locations
+    where id = '40000000-0000-4000-8000-000000000001';
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: B could select created_by off public.locations — the column-level SELECT grant is not withholding it';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — insert spoofing. As C, attempting to insert a location with
+-- created_by set to B's id must fail the INSERT `with check`.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000c1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.locations (name, lat, lng, created_by)
+    values ('C spoofing as B', -33.87, 151.21,
+            '00000000-0000-4000-8000-0000000000b1');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: C created a location with created_by set to B''s id — the INSERT with check is not pinning created_by to the caller';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 4 — positive control for insert + symmetric visibility. As C, insert
+-- a location omitting created_by (relying on the column default) must succeed,
+-- and the new row must then be visible to B too.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000c1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  new_id uuid;
+begin
+  insert into public.locations (name, lat, lng)
+  values ('C''s Market', -37.8136, 144.9631)
+  returning id into new_id;
+
+  if new_id is null then
+    raise exception 'FAIL: C could not insert a location relying on the created_by default';
+  end if;
+
+  if (select count(*) from public.locations where id = new_id) <> 1 then
+    raise exception 'FAIL: C cannot see the location C just created';
+  end if;
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000b1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.locations where name = 'C''s Market') <> 1 then
+    raise exception 'FAIL: B cannot see the location C created — symmetric global visibility is broken';
+  end if;
+end $$;
+
+reset role;
+
+rollback;


### PR DESCRIPTION
## What

Full Slice 4 build: the `locations` table + `nearby_locations` RPC (global,
anonymous per the §0 hard invariant), the native location-permission wrapper,
and the `LocationsScreen` UI — search, create-with-merge-check, and the locked
merge-confirm prompt.

## Native permissions

`expo-location` requests foreground permission in-context, exactly when the
user presses Create — no upfront rationale screen. Denial is **sticky for the
session**: no retry button, no settings deep-link, since neither is asked for
by the spec or `02-DESIGN-REFERENCE.md`, and building one would widen scope
past the acceptance test. A GPS fetch failure *after* permission is granted
(location services off, timeout) is treated as a distinct, retryable error —
not folded into denial.

## UI

- New `Locations` screen, reachable from a second `ListsScreen` header button
  alongside `Household` — independently testable with zero lists in
  existence, per this project's vertical-slice pattern.
- Merge-confirm reuses the existing `Confirm` component with the copy locked
  in `02-DESIGN-REFERENCE.md` § Slice 4, verbatim.
- Manual search filters the already-loaded locations list client-side by
  name — no new backend call, works identically whether permission was
  granted or denied.
- Selecting a location (row tap or merge-confirm) sets an ephemeral,
  client-only "Selected" badge — nothing persisted. Slice 4 has nothing to
  attach a selection *to* yet (that's Slice 5); this gives Slice 5 a working
  UI hook instead of a bare list.
- No ownership/attribution UI anywhere on this screen — `locations.ts`
  already withholds `created_by` from the SELECT grant, and nothing here
  reintroduces the concept client-side.

## Process note

Backend was built and committed in a prior session (`c357f1e`) with no PR
opened since there was no UI yet to review alongside it. This PR carries that
commit plus the two phases built this session, reviewed by a separate
Code-Reviewer pass (two copy bugs found and fixed: a denial message pointing
"below" when the search field is above it, and a zero-locations empty state
that contradicted itself when permission was denied).

## Testing checklist

(from #4, to verify against the Vercel preview once it's up)

- [ ] Creating a location within 100m of an existing one shows the merge
      prompt, naming the existing location and its approximate (nearest-10m)
      distance, rather than silently duplicating
- [ ] Confirming the merge prompt resolves to the existing location and
      creates nothing new; cancelling also creates nothing
- [ ] Denying location permission still allows resolving to an existing
      location via manual search by name, with no location created either way
- [ ] The Locations screen is reachable and usable with zero lists in
      existence
- [ ] `tsc --noEmit` passes
- [ ] `expo export --platform web` succeeds (build doesn't break)
- [ ] Native (iOS/Android) — never run, as always; Vercel preview is the
      agreed review surface. Real-device GPS verification from #4's original
      checklist stays open.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)