### PR TITLE
Slice 5 — Shopping Mode

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "mobile-web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "mobile", "run", "web", "--", "--port", "8082"],
+      "port": 8082
+    }
+  ]
+}

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,16 +5,16 @@
 
 ## Last active
 
-- **Slice 4 is done and merged.** [PR #15](https://github.com/mp3anthony/cartel/pull/15)
-  (backend + native-permissions + UI, built and live-verified across two
-  sessions) merged to `main` as `f3a71c3`, closing issue #4. Feature branch
-  deleted, both locally and on origin.
-- **Next up: Slice 5 — Shopping Mode, issue #5** (`ready-for-agent`, was
-  blocked on #4, now unblocked). Scope: attach a list to a location, enter a
-  shopping view with live check-off. The Locations screen's ephemeral
-  "Selected" `Badge` (see below) exists specifically as this slice's UI hook —
-  nothing persisted yet, that's #5's job.
-- Not yet started; no Investigator/Planner work done for it this session.
+- **Slice 5 — Shopping Mode, issue #5, is built end to end and
+  live-verified.** [PR #16](https://github.com/mp3anthony/cartel/pull/16)
+  (schema + `LocationsScreen` attach wiring + new `ShoppingScreen`) open
+  against `main` on branch `slice-5-shopping-mode`, not yet merged — that's
+  the next decision, not this session's to make.
+- Slice 4 is merged — [PR #15](https://github.com/mp3anthony/cartel/pull/15),
+  `f3a71c3`, closing issue #4 — no longer worth its own entry.
+- **Next up once #16 merges: Slice 6 — Crowdsourced Location Tagging, issue
+  #6** (was blocked on #5, now unblocked). Not yet started; no
+  Investigator/Planner work done for it this session.
 
 ## Notes for next session
 
@@ -29,6 +29,9 @@
   shareable link rather than assuming a bare preview URL loads.
 - Repo was recreated fresh; old sync-engine history was deliberately left behind.
   `origin/main` is always the real `main` if a stale local branch ever disagrees.
+- `.claude/launch.json` (new this slice) runs the web preview on port 8082, not
+  Expo's default 8081 — 8081 was occupied in the session that added it. Use
+  8082 going forward rather than assuming the default.
 
 **Decisions that will look like mistakes if you don't know why**
 - **Realtime is enabled per-table via publication membership, not per-row.**
@@ -64,18 +67,66 @@
   never passed, anywhere.** This database sorts `'a1' < 'A1'` under its default
   ICU collation; base-62 keys only sort correctly under byte order. `03-SPEC.md`
   § Slice 2 has the full mechanism.
-- **`LocationsScreen`'s "Selected" state is ephemeral and client-only — nothing
-  persisted.** Slice 4 had nothing to attach a selected location *to* (`lists`
-  has no location column; that's Slice 5's job), so a row tap or merge-confirm
-  just sets local React state and renders a `Badge`. Don't mistake this for a
-  half-built persistence feature — it's a deliberate placeholder UI hook for
-  Slice 5 to wire real attachment into, not a bug to "finish."
+- **`LocationsScreen`'s "Selected" `Badge` is no longer a placeholder — Slice 5
+  wired it up.** A new optional nav param `Locations: { attachToListId?:
+  string }` and a single `handleSelect()` function are what make a selection
+  "become real": absent the param it's still byte-identical to Slice 4
+  (client-side badge only); present, every path that finalizes a choice (row
+  tap, merge-confirm, just-created location) writes `location_id` via
+  `attachLocation()` and navigates back to `ListDetail` instead. Two slices of
+  HANDOFF called this "not a bug to finish" — it's finished now; don't add a
+  second, parallel selection mechanism if a later slice wants attachment
+  triggered from somewhere other than this screen.
 - **Location-permission denial is sticky for the screen's mounted lifetime,
   with no retry button and no settings deep-link.** Once `requestLocation()`
   comes back non-granted, `LocationsScreen` never asks again until it
   remounts. Deliberately narrower than a shipped consumer app would want —
   built to satisfy issue #4's acceptance test exactly, not more. If a later
   slice wants a "check settings" flow, that's new scope, not a gap to patch.
+- **No `shop_sessions` table this slice, and no RPC for the `location_id`
+  write.** `lists.location_id` (migration
+  `20260810000006_lists_location_attachment.sql`) is a plain nullable FK, `on
+  delete set null` (mirrors `locations.created_by`'s own deletion story),
+  gated by the pre-existing `lists_update_visible` RLS policy plus a new
+  column-level `grant update (location_id)` — no new policy, because that
+  predicate already has no per-column awareness to add one for. "Closed and
+  resumed without losing check-off state" is satisfied entirely by
+  `list_items.checked_at` (already existed since Slice 2, already persists,
+  `useListItems` already reloads fresh on every mount) — `shop_sessions` is
+  real but later scope (Slice 7/9, feeds history/route-learning), and
+  building it now would be schema nobody reads yet. Confirmed by
+  `supabase/tests/rls_lists_locations.sql` (6 assertions plus a positive
+  control, following the `rls_lists.sql`/`rls_locations.sql` template) —
+  including that a household mate may attach too (equal-rank invariant) and
+  that `public.locations` stays globally visible to a stranger regardless
+  (§0's household-private/location-global boundary still holds).
+- **`attachLocation(client, listId, locationId)` is one function for attach,
+  change, and detach** — detach is just a call with `null`. A separate
+  `detachLocation` would only be this call with its second argument
+  hard-coded.
+- **`ShoppingScreen` tracks per-item pending state (`Set<string>` of
+  in-flight item ids) instead of `ListDetailScreen`'s one shared `busy`
+  boolean.** Deliberate: Shopping Mode's whole point is checking off several
+  items in quick succession while walking, so one shared flag would
+  serialize every tap behind the previous row's round trip. The `Set` only
+  guards a row against double-tapping itself — different rows are free to be
+  in flight together.
+- **`CheckTarget` grew optional `size`/`label` props rather than a new
+  parallel component.** When `label` is passed, the whole row (circle + text)
+  renders as one `Pressable` — deliberately not a bare-circle `CheckTarget`
+  nested inside a `Row`'s own `onPress`, which `Row`'s own doc comment already
+  flags as two touchables reacting to one tap. Both props default to values
+  that leave every pre-Slice-5 call site (`ListDetailScreen`'s per-item
+  circle, `ListsScreen`'s share checkbox) rendering byte-identically. Two new
+  tokens ride along in `tokens.ts`: `fontSize.large` (26) and
+  `minTouchTargetLarge` (64, Material's "large touch target" tier), both
+  Shopping-Mode-only — `tokens.ts` had carried a comment since Slice 4
+  anticipating this ("Shopping Mode raises it in Slice 5"), now resolved as a
+  sibling token rather than a replacement of `minTouchTarget`.
+- **No "Finish shopping" button, no reordering or grouping of checked items in
+  `ShoppingScreen`.** Out of scope by this slice's own plan — there's no
+  session row to finalize, and Slice 2 already decided check-off never writes
+  `position`.
 
 **Traps**
 - RLS policy expressions run as the *querying* user. Revoking a policy-helper
@@ -87,6 +138,24 @@
   the deletion. This was a theoretical risk recorded in Slice 2 and a live-verified
   fact as of Slice 3 — the soft-delete UPDATE was confirmed arriving over both
   sessions' subscriptions before the client-side filter hid the row.
+- **Two mounted `useListItems` instances for the same `listId` collide on the
+  same Realtime channel and crash.** `ListDetailScreen` stays mounted
+  underneath `ShoppingScreen` in the native-stack navigator when navigating
+  between them, so both hooks called `client.channel('list-items:<id>')`
+  with the same bare topic — Supabase's `client.channel(topic)` returns the
+  *existing* channel for a topic it's already seen rather than creating a new
+  one, and calling `.on()` on a channel that's already `subscribe()`d throws.
+  Slice 3's original doc comment on `useListItems` had explicitly flagged
+  this as theoretically possible but left it undefended as "not reachable
+  today"; Slice 5 made it reachable and it crashed live (an uncaught error on
+  `ShoppingScreen`) before the fix. Fixed by suffixing the channel topic with
+  a per-mount-instance `useId()` (`mobile/src/hooks/useListItems.ts`) — both
+  instances still filter server-side on the same `list_id`, so two screens
+  showing the same list now redundantly self-refresh on each other's writes
+  too, accepted under the same "redundant but harmless" reasoning `useLists`
+  already relies on for a write's own echo. Watch for this again any time a
+  future slice mounts a second concurrent consumer of the same list-scoped
+  hook.
 - **Two tabs of one browser profile are the same user.** `localStorage` is shared
   per-origin, not per-tab. Genuine two-session verification needs two separate
   browser profiles (Browser pane + Claude-in-Chrome), confirmed by checking the

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -21,6 +21,7 @@ import { HouseholdSetupScreen } from './src/screens/HouseholdSetupScreen';
 import { ListDetailScreen } from './src/screens/ListDetailScreen';
 import { ListsScreen } from './src/screens/ListsScreen';
 import { LocationsScreen } from './src/screens/LocationsScreen';
+import { ShoppingScreen } from './src/screens/ShoppingScreen';
 import { ThemeProvider, useTheme } from './src/theme/ThemeProvider';
 import type { Tokens } from './src/theme/tokens';
 
@@ -41,6 +42,10 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
  * the navigator was adopted to fix, reintroduced through the door deep links use. The
  * navigator's own `initialRouteName` does not cover this; a state rehydrated from a
  * URL is used as given.
+ *
+ * `Locations` carries no path template for `attachToListId` — that param is only
+ * ever set via in-app `navigation.navigate(...)` from ListDetailScreen, never a URL,
+ * so there is nothing for the linking config to parse out of a path.
  */
 const linking: LinkingOptions<RootStackParamList> = {
   prefixes: ['cartel://'],
@@ -52,6 +57,7 @@ const linking: LinkingOptions<RootStackParamList> = {
       HouseholdSetup: 'household/setup',
       Household: 'household',
       Locations: 'locations',
+      Shopping: 'shop/:listId',
     },
   },
 };
@@ -165,7 +171,21 @@ function Bootstrapped({ env }: { env: Env }) {
         </Stack.Screen>
 
         <Stack.Screen name="Locations" options={{ title: 'Locations' }}>
-          {(props) => <LocationsScreen {...props} client={client} />}
+          {(props) => (
+            <LocationsScreen
+              {...props}
+              client={client}
+              onListsChanged={lists.refresh}
+            />
+          )}
+        </Stack.Screen>
+
+        {/* Title is a placeholder for the same reason ListDetail's is: the screen
+            replaces it with the list's name once the index resolves. */}
+        <Stack.Screen name="Shopping" options={{ title: 'Shopping' }}>
+          {(props) => (
+            <ShoppingScreen {...props} client={client} lists={lists.view} />
+          )}
         </Stack.Screen>
 
         {state.status === 'none' ? (

--- a/mobile/src/components/ui.tsx
+++ b/mobile/src/components/ui.tsx
@@ -273,20 +273,78 @@ export function Row({
  * `accessibilityLabel` is required because the visible content is a glyph. In a Row
  * the neighbouring label reads as the name to a sighted user, but nothing in the
  * accessibility tree connects the two, so the control has to name itself.
+ *
+ * `size` and `label` are Shopping Mode's addition (Slice 5), both optional and
+ * backward compatible — every call site that omits them renders exactly as before.
+ * `label`, when present, folds the row's label into this same `Pressable` rather
+ * than leaving `CheckTarget` a bare circle for a `Row`'s `leading` slot to wrap in
+ * its *own* `onPress`. `Row`'s own doc comment already establishes why: a circle
+ * nested inside another row's touchable is two nested `Pressable`s reacting to one
+ * tap, which is the pattern to avoid, not a component to build. Folding the label in
+ * here keeps it to one `Pressable` and reuses the dual `aria-checked`/
+ * `accessibilityState` spelling below rather than re-deriving that react-native-web
+ * 0.21 gap for a second component. Checked state on the label is strikethrough plus
+ * muted colour, on top of the same glyph-and-fill the bare circle already uses —
+ * colour is never the only signal, on the label any more than on the circle.
  */
 export function CheckTarget({
   checked,
   onToggle,
   accessibilityLabel,
   disabled = false,
+  size = 'default',
+  label,
 }: {
   checked: boolean;
   onToggle: () => void;
   accessibilityLabel: string;
   disabled?: boolean;
+  size?: 'default' | 'large';
+  label?: string;
 }) {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const large = size === 'large';
+
+  const circle = (
+    <View
+      style={[
+        styles.checkCircle,
+        large && styles.checkCircleLarge,
+        checked && styles.checkCircleChecked,
+      ]}
+    >
+      {checked ? (
+        <Text style={[styles.checkGlyph, large && styles.checkGlyphLarge]}>✓</Text>
+      ) : null}
+    </View>
+  );
+
+  if (label !== undefined) {
+    return (
+      <Pressable
+        accessibilityRole="checkbox"
+        accessibilityLabel={accessibilityLabel}
+        aria-checked={checked}
+        accessibilityState={{ checked, disabled }}
+        disabled={disabled}
+        onPress={onToggle}
+        style={({ pressed }) => [
+          styles.checkRow,
+          pressed && styles.rowPressed,
+          disabled && styles.buttonInactive,
+        ]}
+      >
+        {circle}
+        <Text
+          numberOfLines={2}
+          style={[styles.checkRowLabel, checked && styles.checkRowLabelChecked]}
+        >
+          {label}
+        </Text>
+      </Pressable>
+    );
+  }
 
   return (
     <Pressable
@@ -302,14 +360,12 @@ export function CheckTarget({
       disabled={disabled}
       onPress={onToggle}
       style={({ pressed }) => [
-        styles.touchTarget,
+        large ? styles.touchTargetLarge : styles.touchTarget,
         pressed && styles.touchTargetPressed,
         disabled && styles.buttonInactive,
       ]}
     >
-      <View style={[styles.checkCircle, checked && styles.checkCircleChecked]}>
-        {checked ? <Text style={styles.checkGlyph}>✓</Text> : null}
-      </View>
+      {circle}
     </Pressable>
   );
 }
@@ -604,6 +660,15 @@ function createStyles(tokens: Tokens) {
     touchTargetPressed: {
       backgroundColor: tokens.color.surfaceSunken,
     },
+    // Shopping Mode's bare-circle sizing (size="large", no label) — same shape as
+    // touchTarget, floored at the large tier instead of the default one.
+    touchTargetLarge: {
+      width: tokens.minTouchTargetLarge,
+      height: tokens.minTouchTargetLarge,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: tokens.radius.pill,
+    },
     checkCircle: {
       width: tokens.space.lg,
       height: tokens.space.lg,
@@ -612,6 +677,12 @@ function createStyles(tokens: Tokens) {
       borderColor: tokens.color.border,
       alignItems: 'center',
       justifyContent: 'center',
+    },
+    // Shopping Mode's larger circle — bigger than the default row's, still well
+    // short of the 64pt touch target box it sits inside.
+    checkCircleLarge: {
+      width: tokens.space.xl,
+      height: tokens.space.xl,
     },
     checkCircleChecked: {
       backgroundColor: tokens.color.accent,
@@ -622,6 +693,32 @@ function createStyles(tokens: Tokens) {
       fontSize: tokens.fontSize.caption,
       fontWeight: '700',
       lineHeight: tokens.fontSize.caption,
+    },
+    checkGlyphLarge: {
+      fontSize: tokens.fontSize.title,
+      lineHeight: tokens.fontSize.title,
+    },
+    // Shopping Mode's full-width row: circle and label in one Pressable, floored at
+    // the large touch target rather than the default one — see CheckTarget's doc
+    // comment for why this isn't a Row wrapping a bare CheckTarget.
+    checkRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: tokens.space.md,
+      minHeight: tokens.minTouchTargetLarge,
+      paddingHorizontal: tokens.space.md,
+      paddingVertical: tokens.space.sm,
+      backgroundColor: tokens.color.surface,
+      borderRadius: tokens.radius.md,
+    },
+    checkRowLabel: {
+      flex: 1,
+      fontSize: tokens.fontSize.large,
+      color: tokens.color.textPrimary,
+    },
+    checkRowLabelChecked: {
+      color: tokens.color.textSecondary,
+      textDecorationLine: 'line-through',
     },
     iconGlyph: {
       color: tokens.color.textPrimary,

--- a/mobile/src/hooks/useListItems.ts
+++ b/mobile/src/hooks/useListItems.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import { loadItems, type ListItemRow } from '../lib/lists';
@@ -24,6 +24,9 @@ export type ItemsView =
 export function useListItems(client: SupabaseClient, listId: string) {
   const [view, setView] = useState<ItemsView>({ status: 'loading' });
   const active = useRef(true);
+  // Distinguishes this mounted instance's channel from any other instance's, for
+  // the same listId — see the subscription effect below for why that now matters.
+  const instanceId = useId();
 
   // Declared before the loading effect so its cleanup runs first on unmount.
   useEffect(() => {
@@ -73,14 +76,23 @@ export function useListItems(client: SupabaseClient, listId: string) {
     // the screen switches to a different list, not stay attached to the one it first
     // subscribed to.
     //
-    // Current navigation never pushes a second `ListDetail` instance for the same
-    // listId — nothing in this screen navigates to itself — so two subscriptions
-    // colliding on the same channel name `list-items:<id>` is not reachable today.
-    // Left undefended rather than solved: if it ever became reachable, two
-    // identically-named channel subscriptions would have version-inconsistent
-    // supabase-js behaviour, but there is nothing to design against yet.
+    // The topic carries `instanceId`, not just `listId`. Slice 3's comment here
+    // used to say a second concurrent mount of this hook for the same list was
+    // unreachable and so left undefended; Slice 5 made it reachable —
+    // `ListDetailScreen` stays mounted underneath when it navigates to
+    // `ShoppingScreen`, and both call this hook for the same list id. Supabase's
+    // `client.channel(topic)` returns the *existing* channel for a topic it has
+    // already seen rather than creating a second one, so two instances sharing a
+    // bare `list-items:<id>` topic would both grab the same already-`subscribe()`d
+    // channel object, and the second instance's `.on()` call throws — reproduced
+    // live (an uncaught error crashing the newer screen) before this fix landed.
+    // Suffixing the topic per mounted instance gives each its own channel; both
+    // still filter on the same `list_id`, so both still hear the same Postgres
+    // events, which duplicates a refresh between two screens showing the same list
+    // at once — the same "redundant but harmless" tradeoff `useLists`'s own doc
+    // comment already accepts for a write's own echo.
     const channel = client
-      .channel(`list-items:${listId}`)
+      .channel(`list-items:${listId}:${instanceId}`)
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'list_items', filter: `list_id=eq.${listId}` },
@@ -93,7 +105,7 @@ export function useListItems(client: SupabaseClient, listId: string) {
     return () => {
       void client.removeChannel(channel);
     };
-  }, [client, listId, refresh]);
+  }, [client, listId, instanceId, refresh]);
 
   return { view, refresh };
 }

--- a/mobile/src/lib/lists.ts
+++ b/mobile/src/lib/lists.ts
@@ -7,6 +7,7 @@ export type ListRow = {
   id: string;
   name: string;
   householdId: string | null;
+  locationId: string | null;
   createdAt: string;
 };
 
@@ -26,6 +27,7 @@ type ListRecord = {
   id: string;
   name: string;
   household_id: string | null;
+  location_id: string | null;
   created_at: string;
 };
 
@@ -72,7 +74,7 @@ export async function loadLists(client: SupabaseClient): Promise<Outcome<ListRow
   // deletion. Filtering it here is the whole of the mechanism.
   const { data, error } = await client
     .from('lists')
-    .select('id, name, household_id, created_at')
+    .select('id, name, household_id, location_id, created_at')
     .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
@@ -88,6 +90,7 @@ export async function loadLists(client: SupabaseClient): Promise<Outcome<ListRow
       id: row.id,
       name: row.name,
       householdId: row.household_id,
+      locationId: row.location_id,
       createdAt: row.created_at,
     })),
   };
@@ -168,6 +171,34 @@ export async function promoteList(
   const { error } = await client.rpc('promote_to_household', {
     target_list_id: listId,
   });
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Points a list at a location, or (passing null) clears the attachment. One
+ * function for all three cases — attach, change, remove — because they are the
+ * same UPDATE with a different value; a separate `detachLocation` would just be
+ * this call with its second argument hard-coded to null.
+ *
+ * `.eq('id', listId)` names the row; it does not authorise the write. The existing
+ * `lists_update_visible` policy already covers this column (see migration
+ * 20260810000006's header) — any household member may call this, not only the
+ * list's owner, matching 03-SPEC.md's "all members equal rank".
+ */
+export async function attachLocation(
+  client: SupabaseClient,
+  listId: string,
+  locationId: string | null,
+): Promise<Outcome<void>> {
+  const { error } = await client
+    .from('lists')
+    .update({ location_id: locationId })
+    .eq('id', listId);
 
   if (error) {
     return { ok: false, message: humanise(error) };

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -18,5 +18,15 @@ export type RootStackParamList = {
   ListDetail: { listId: string };
   HouseholdSetup: undefined;
   Household: undefined;
-  Locations: undefined;
+  /**
+   * `attachToListId` is Slice 5's addition. Absent, this screen behaves exactly as
+   * Slice 4 left it — a plain browse/create index with an ephemeral "Selected"
+   * badge. Present, a finalized selection (row tap, merge-confirm, or a
+   * just-created location) writes that location onto the named list instead of
+   * merely badging it, then returns to that list. Only ever set via in-app
+   * `navigation.navigate(...)`, never a URL — see `linking.config.screens` in
+   * App.tsx for why it carries no path template of its own.
+   */
+  Locations: { attachToListId?: string } | undefined;
+  Shopping: { listId: string };
 };

--- a/mobile/src/screens/ListDetailScreen.tsx
+++ b/mobile/src/screens/ListDetailScreen.tsx
@@ -5,6 +5,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
   Badge,
+  Body,
   CheckTarget,
   Confirm,
   EmptyState,
@@ -19,9 +20,11 @@ import {
 } from '../components/ui';
 import { useListItems } from '../hooks/useListItems';
 import type { ListsView } from '../hooks/useLists';
+import { useLocations } from '../hooks/useLocations';
 import type { Outcome } from '../lib/household';
 import {
   addItem,
+  attachLocation,
   moveItem,
   promoteList,
   removeItem,
@@ -63,6 +66,10 @@ export function ListDetailScreen({
   const styles = useMemo(() => createStyles(tokens), [tokens]);
   const { listId } = route.params;
   const { view, refresh } = useListItems(client, listId);
+  // Resolves the attached location's display name only — attaching/detaching itself
+  // is a plain write on the `lists` row via attachLocation(), not anything this hook
+  // owns. No `refresh` taken from here: nothing on this screen creates a location.
+  const { view: locationsView } = useLocations(client);
 
   const [draft, setDraft] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -186,6 +193,13 @@ export function ListDetailScreen({
     );
   }
 
+  function removeLocation() {
+    // `location_id` lives on the `lists` row the app-wide index holds, not on
+    // anything useListItems reloads — same reasoning as share()/renameList() above,
+    // so onListsChanged is what settles this screen and the Lists screen behind it.
+    void mutate(() => attachLocation(client, listId, null), onListsChanged);
+  }
+
   function startRenameList() {
     if (!list) {
       return;
@@ -256,10 +270,48 @@ export function ListDetailScreen({
 
   const items = view.status === 'loaded' ? view.items : [];
   const canShare = list.householdId === null && inHousehold;
+  const attachedLocation =
+    list.locationId && locationsView.status === 'loaded'
+      ? locationsView.locations.find((location) => location.id === list.locationId) ??
+        null
+      : null;
 
   return (
     <Screen edges={NAVIGATOR_EDGES} align="top" scroll>
       <Badge label={list.householdId ? 'Shared' : 'Personal'} />
+
+      {list.locationId ? (
+        <>
+          <Body>
+            {attachedLocation
+              ? `Shopping at ${attachedLocation.name}`
+              : 'Shopping at a location'}
+          </Body>
+          <SecondaryButton
+            label="Start shopping"
+            onPress={() => navigation.navigate('Shopping', { listId })}
+            disabled={busy}
+          />
+          <SecondaryButton
+            label="Change location"
+            onPress={() =>
+              navigation.navigate('Locations', { attachToListId: listId })
+            }
+            disabled={busy}
+          />
+          <SecondaryButton
+            label="Remove location"
+            onPress={removeLocation}
+            disabled={busy}
+          />
+        </>
+      ) : (
+        <SecondaryButton
+          label="Attach a location"
+          onPress={() => navigation.navigate('Locations', { attachToListId: listId })}
+          disabled={busy}
+        />
+      )}
 
       <Field
         label="Add an item"

--- a/mobile/src/screens/LocationsScreen.tsx
+++ b/mobile/src/screens/LocationsScreen.tsx
@@ -18,6 +18,7 @@ import {
 } from '../components/ui';
 import { useLocations } from '../hooks/useLocations';
 import { requestLocation } from '../lib/geolocation';
+import { attachLocation } from '../lib/lists';
 import {
   createLocation,
   findNearbyLocations,
@@ -31,6 +32,7 @@ import type { Tokens } from '../theme/tokens';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Locations'> & {
   client: SupabaseClient;
+  onListsChanged: () => Promise<void>;
 };
 
 /**
@@ -41,18 +43,28 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Locations'> & {
  * made". `locations.ts` already withholds `created_by` from the SELECT grant — there
  * is no ownership concept here to accidentally add.
  *
- * `selected` is client-side and ephemeral. Nothing about "which location is
- * selected" is persisted or sent to the backend; it exists only so a row can show a
- * "Selected" badge for the rest of this screen's mounted lifetime.
+ * `selected` is client-side and ephemeral when `attachToListId` is absent — nothing
+ * about "which location is selected" is persisted or sent to the backend in that
+ * case; it exists only so a row can show a "Selected" badge for the rest of this
+ * screen's mounted lifetime. This is Slice 4's whole selection story, unchanged.
  *
  * `permissionDenied` is sticky for the same lifetime, once set. There is no retry
  * button and no settings deep link this phase — a user who denies location access
  * falls back to searching the existing index for the rest of this visit.
+ *
+ * `attachToListId` (Slice 5) is what turns a selection from client-side badging
+ * into a real write. `handleSelect` is the one place a selection "becomes real" —
+ * every path that finalizes a choice (row tap, merge-confirm, just-created-location)
+ * calls it rather than setting `selected` directly, so the attach-vs-badge branch
+ * lives in exactly one function. Absent, `handleSelect` does exactly what this
+ * screen did before Slice 5 existed; present, it writes `location_id` onto that list
+ * and returns to it instead.
  */
-export function LocationsScreen({ client }: Props) {
+export function LocationsScreen({ client, navigation, onListsChanged, route }: Props) {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
   const { view, refresh } = useLocations(client);
+  const attachToListId = route.params?.attachToListId;
 
   const [search, setSearch] = useState('');
   const [composing, setComposing] = useState(false);
@@ -64,6 +76,43 @@ export function LocationsScreen({ client }: Props) {
   const [selected, setSelected] = useState<{ id: string; name: string } | null>(
     null,
   );
+
+  /**
+   * The single place a selection "becomes real". Absent `attachToListId`, this is
+   * byte-identical to Slice 4's row tap: set the ephemeral badge state and stop.
+   * Present, it writes instead — `.eq('id', ...)`-style scoping and RLS already
+   * cover who may attach (see migration 20260810000006), so this never re-derives
+   * an authorization check the database already makes.
+   *
+   * The `busy` guard only applies on the attach path: a bare badge-select has
+   * nothing to race, so gating it here too would make the no-`attachToListId`
+   * branch stop being byte-identical to before.
+   */
+  async function handleSelect(id: string, name: string) {
+    if (!attachToListId) {
+      setSelected({ id, name });
+      return;
+    }
+
+    if (busy) {
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+
+    const outcome = await attachLocation(client, attachToListId, id);
+
+    if (!outcome.ok) {
+      setBusy(false);
+      setError(outcome.message);
+      return;
+    }
+
+    await onListsChanged();
+    setBusy(false);
+    navigation.navigate('ListDetail', { listId: attachToListId });
+  }
 
   function beginComposing() {
     setError(null);
@@ -129,11 +178,15 @@ export function LocationsScreen({ client }: Props) {
       return;
     }
 
+    // Captured before setName('') clears it, and before handleSelect's own attach
+    // path may navigate this screen away.
+    const createdName = name.trim();
+
     await refresh();
     setBusy(false);
     setComposing(false);
-    setSelected({ id: created.value, name: name.trim() });
     setName('');
+    await handleSelect(created.value, createdName);
   }
 
   function confirmMerge() {
@@ -141,9 +194,11 @@ export function LocationsScreen({ client }: Props) {
       return;
     }
 
-    // No write: the nearby location already exists, so "using" it is purely a
-    // client-side selection.
-    setSelected({ id: nearbyMatch.id, name: nearbyMatch.name });
+    // The nearby location already exists, so there is no write for the location
+    // itself here — "using" it is either a client-side selection (byte-identical to
+    // before) or the same attach write every other selection path uses, decided by
+    // handleSelect, not here.
+    void handleSelect(nearbyMatch.id, nearbyMatch.name);
     setNearbyMatch(null);
     setComposing(false);
     setName('');
@@ -191,7 +246,7 @@ export function LocationsScreen({ client }: Props) {
         <Row
           key={location.id}
           label={location.name}
-          onPress={() => setSelected({ id: location.id, name: location.name })}
+          onPress={() => void handleSelect(location.id, location.name)}
           trailing={
             location.id === selected?.id ? <Badge label="Selected" /> : undefined
           }

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -1,0 +1,191 @@
+import { useLayoutEffect, useState } from 'react';
+import { ActivityIndicator } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  Body,
+  CheckTarget,
+  EmptyState,
+  ErrorNote,
+  NAVIGATOR_EDGES,
+  Screen,
+} from '../components/ui';
+import { useListItems } from '../hooks/useListItems';
+import type { ListsView } from '../hooks/useLists';
+import { setChecked, type ListItemRow } from '../lib/lists';
+import type { RootStackParamList } from '../navigation/types';
+import { useTheme } from '../theme/ThemeProvider';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
+  client: SupabaseClient;
+  lists: ListsView;
+};
+
+/**
+ * The oversized, one-item-per-row check-off screen a shopper walks through.
+ *
+ * Per-item pending state (a `Set<string>` of in-flight item ids), not one shared
+ * `busy` boolean like `ListDetailScreen`'s `mutate()`: Shopping Mode's whole point
+ * is checking several items off in quick succession while walking, so serializing
+ * every row behind a single flag would make the second tap wait on the first row's
+ * round trip for no reason. The `Set` only guards a row against racing itself — a
+ * second tap on the *same* item before its first write lands — which is the one
+ * case double-firing would actually corrupt (two in-flight writes toggling the same
+ * `checked_at` back and forth). Different rows are free to be in flight together.
+ *
+ * "Closed and resumed without losing check-off state" needs no new mechanism here.
+ * `toggle()` awaits `setChecked()` before calling `refresh()`, so the UI only ever
+ * shows a checked state the database has already accepted — never optimistic. This
+ * screen holds no check-off state of its own beyond that one pending `Set`, which
+ * matters only while a row's own write is in flight and is worthless the moment
+ * that write lands or the screen unmounts. Re-entering Shopping for the same
+ * `listId` — button, deep-link URL, or cold restart landing here — mounts a fresh
+ * `useListItems`, which runs a plain `SELECT ... where list_id = listId` and reads
+ * back whatever `checked_at` is currently stored. There is no `shop_sessions` row
+ * to resume and nothing here to reconstruct.
+ *
+ * No reordering, grouping, or "Finish shopping" button — out of scope per this
+ * slice's plan: items render in whatever order `useListItems` returns, unchanged,
+ * and there is no session row to finalize.
+ */
+export function ShoppingScreen({ client, lists, navigation, route }: Props) {
+  const tokens = useTheme();
+  const { listId } = route.params;
+  const { view, refresh } = useListItems(client, listId);
+  const [pending, setPending] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const list =
+    lists.status === 'loaded'
+      ? lists.lists.find((candidate) => candidate.id === listId) ?? null
+      : null;
+
+  useLayoutEffect(() => {
+    // Same reasoning as ListDetailScreen's header: it carries the list's name, and
+    // it's what carries back too.
+    if (list) {
+      navigation.setOptions({ title: list.name });
+    }
+  }, [list, navigation]);
+
+  async function toggle(item: ListItemRow) {
+    if (pending.has(item.id)) {
+      return;
+    }
+
+    setPending((current) => new Set(current).add(item.id));
+    setError(null);
+
+    try {
+      const outcome = await setChecked(client, item.id, item.checkedAt === null);
+
+      if (!outcome.ok) {
+        setError(outcome.message);
+        return;
+      }
+
+      await refresh();
+    } finally {
+      setPending((current) => {
+        const next = new Set(current);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  }
+
+  if (lists.status === 'loading') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ActivityIndicator color={tokens.color.accent} size="large" />
+      </Screen>
+    );
+  }
+
+  if (lists.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={lists.message} />
+      </Screen>
+    );
+  }
+
+  if (!list) {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <EmptyState
+          heading="This list isn’t here"
+          body="It may have been removed, or it may belong to someone else."
+          actionLabel="Back to your lists"
+          onAction={() => navigation.navigate('Lists')}
+        />
+      </Screen>
+    );
+  }
+
+  if (list.locationId === null) {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <EmptyState
+          heading="No location attached"
+          body="Attach a location to this list before you start shopping."
+          actionLabel="Back to list"
+          onAction={() => navigation.navigate('ListDetail', { listId })}
+        />
+      </Screen>
+    );
+  }
+
+  if (view.status === 'loading') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ActivityIndicator color={tokens.color.accent} size="large" />
+      </Screen>
+    );
+  }
+
+  if (view.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={view.message} />
+      </Screen>
+    );
+  }
+
+  if (view.items.length === 0) {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <EmptyState
+          heading="Nothing to shop for"
+          body="This list has no items yet."
+          actionLabel="Back to list"
+          onAction={() => navigation.navigate('ListDetail', { listId })}
+        />
+      </Screen>
+    );
+  }
+
+  const items = view.items;
+  const checkedCount = items.filter((item) => item.checkedAt !== null).length;
+
+  return (
+    <Screen edges={NAVIGATOR_EDGES} align="top" scroll>
+      <Body>{`${checkedCount} of ${items.length} checked`}</Body>
+
+      {error ? <ErrorNote message={error} /> : null}
+
+      {items.map((item) => (
+        <CheckTarget
+          key={item.id}
+          size="large"
+          label={item.name}
+          checked={item.checkedAt !== null}
+          onToggle={() => void toggle(item)}
+          disabled={pending.has(item.id)}
+          accessibilityLabel={item.name}
+        />
+      ))}
+    </Screen>
+  );
+}

--- a/mobile/src/theme/tokens.ts
+++ b/mobile/src/theme/tokens.ts
@@ -61,6 +61,9 @@ export const tokens = {
     body: 16,
     title: 22,
     display: 30,
+    /** Shopping Mode's item text only. Clears the ~24px "large text" WCAG 3:1
+     * contrast threshold per 02-DESIGN-REFERENCE.md's Glanceability section. */
+    large: 26,
   },
 
   /**
@@ -79,8 +82,11 @@ export const tokens = {
     },
   },
 
-  /** Design reference sets 44pt as the floor; Shopping Mode raises it in Slice 5. */
+  /** Design reference sets 44pt as the floor for every ordinary control. */
   minTouchTarget: 44,
+  /** Shopping Mode only — Material Design's "large touch target" tier, for the
+   * oversized check-off rows a user taps while walking and not looking closely. */
+  minTouchTargetLarge: 64,
 } as const;
 
 export type Tokens = typeof tokens;

--- a/supabase/migrations/20260810000006_lists_location_attachment.sql
+++ b/supabase/migrations/20260810000006_lists_location_attachment.sql
@@ -1,0 +1,45 @@
+-- Slice 5 — Shopping Mode: list ↔ location attachment.
+--
+-- Adds a single nullable FK from `lists` to `locations` so a list can be attached to
+-- (and, by writing null, detached from) the supermarket it is shopped at. This is
+-- deliberately the whole of this slice's schema change — no `shop_sessions` table,
+-- no session-state column anywhere. The acceptance test only asks that check-off
+-- state survive closing and reopening Shopping Mode, and that state already lives on
+-- `list_items.checked_at` (Slice 2) and already persists: `useListItems` reloads
+-- from the database on every mount, so "close and resume" falls out of existing
+-- behaviour once a list can point at a location at all. A `shop_sessions` table is
+-- real, later scope (03-SPEC.md § 1, § Slice 9 "feeds both history and route
+-- learning") — building it now would be schema nobody reads yet.
+--
+-- `on delete set null`, not cascade: `locations` is shared/global infrastructure
+-- (03-SPEC.md § 0) that must not carry knowledge of who has a list pointed at it, and
+-- a location disappearing (no delete path exists yet, but one might later) must not
+-- take a household's list down with it. Mirrors `locations.created_by`'s own
+-- `on delete set null` in migration 20260810000005, for the same reason.
+--
+-- No new RLS policy. `lists_update_visible` (migration 20260810000003) already gates
+-- every UPDATE on this table by "owner or household member", evaluated via its
+-- `using`/`with check` pair — that predicate has no per-column awareness, so it
+-- already covers `location_id` exactly as it covers `name`. The one thing a policy
+-- genuinely cannot do is what the column-level grant below does instead: switching a
+-- column on or off. This migration deliberately does NOT touch `lists_update_visible`.
+--
+-- No RPC. Per 03-SPEC.md's Slice 2 precedent (restated in HANDOFF.md): a plain
+-- column UPDATE gets an RPC only when there's a real atomicity/authorization
+-- invariant RLS can't express in a `with check`. Attaching a location has none —
+-- "may I write this list" is exactly the existing row-level predicate, and "does
+-- this location exist" is exactly what the FK constraint below already enforces (an
+-- attach to a nonexistent location id fails with a foreign-key violation, not a
+-- silent write). Any household member may attach/change/remove a location the same
+-- way any of them may check off an item — 03-SPEC.md's "all members equal rank"
+-- applies here with no special-casing to the list owner.
+
+alter table public.lists
+  add column location_id uuid references public.locations (id) on delete set null;
+
+-- Same reasoning as every other column-level grant in this project (see
+-- 20260810000003's header): the blanket `revoke all` already ran when `lists` was
+-- created, so a newly added column starts with NO privilege, not an inherited one —
+-- this grant is the only thing that makes it writable at all, not an addition to an
+-- already-open door.
+grant update (location_id) on table public.lists to authenticated;

--- a/supabase/tests/rls_lists_locations.sql
+++ b/supabase/tests/rls_lists_locations.sql
@@ -1,0 +1,247 @@
+-- RLS/grant tests for lists.location_id (Slice 5 — Shopping Mode attachment).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- WHAT IT IS REALLY GUARDING. Migration 20260810000006 adds `lists.location_id`
+-- without touching `lists_update_visible` — the claim being tested is that the
+-- existing owner-or-household-member predicate already covers the new column with
+-- no policy change, and that the column-level UPDATE grant added alongside it is
+-- what makes the column writable at all. Assertions 1-2 are the positive half (owner
+-- can write it; a household member who is NOT the owner can too, because
+-- 03-SPEC.md's "all members equal rank" applies here exactly as it does to
+-- check-off); assertions 3-4 are the negative half (a household mate cannot reach a
+-- list outside their household, a stranger cannot reach either list); assertion 5
+-- checks the FK does real work, not just a UI-level convenience; assertion 6 checks
+-- that `public.locations` — deliberately global per 03-SPEC.md § 0 — is untouched by
+-- this migration and stays visible to someone with no relationship to the attaching
+-- household. There is no assertion for "does `public.locations` leak which lists are
+-- attached to it" because there is nothing to query: the FK is one-directional and
+-- `locations` has no back-reference column, so that half of the boundary is enforced
+-- by the schema's shape, not by a policy a test could defeat. Locations have no
+-- soft-delete (`public.locations` has no `deleted_at` column at all, per migration
+-- 20260810000005), so there is no soft-deleted-location edge case to test here.
+--
+-- Fixtures are the premise, not the thing under test, so they are inserted as the
+-- owning role, which bypasses RLS. Only the assertions run as `authenticated`.
+-- `request.jwt.claims` must be set *before* the role switch: after it, the session
+-- no longer has the privilege to set the GUC on some configurations, and auth.uid()
+-- reads that GUC.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. A and D share household H. B shares nothing with either of them.
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-00000000005a', true),  -- A: household member, owns both lists below
+  ('00000000-0000-4000-8000-00000000005d', true),  -- D: same household as A, owns neither list
+  ('00000000-0000-4000-8000-00000000005b', true);  -- B: no household, no relation to A or D
+
+insert into public.households (id, name) values
+  ('50000000-0000-4000-8000-000000000001', 'Test Household');
+
+insert into public.household_members (user_id, household_id) values
+  ('00000000-0000-4000-8000-00000000005a', '50000000-0000-4000-8000-000000000001'),
+  ('00000000-0000-4000-8000-00000000005d', '50000000-0000-4000-8000-000000000001');
+
+insert into public.locations (id, name, lat, lng, created_by) values
+  ('60000000-0000-4000-8000-000000000001',
+   'Test Supermarket', -43.5321, 172.6362,
+   '00000000-0000-4000-8000-00000000005a');
+
+insert into public.lists (id, owner_id, household_id, name) values
+  ('70000000-0000-4000-8000-000000000001',
+   '00000000-0000-4000-8000-00000000005a', null,
+   'A personal'),
+  ('70000000-0000-4000-8000-000000000002',
+   '00000000-0000-4000-8000-00000000005a', '50000000-0000-4000-8000-000000000001',
+   'A household');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control, as A.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.lists
+      where id in ('70000000-0000-4000-8000-000000000001',
+                    '70000000-0000-4000-8000-000000000002')) <> 2 then
+    raise exception 'FAIL: A cannot see A''s own two lists (policies hiding everything; the assertions below would prove nothing)';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — owner writes their own personal list's location_id.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists
+  set location_id = '60000000-0000-4000-8000-000000000001'
+  where id = '70000000-0000-4000-8000-000000000001';
+
+  if (select location_id from public.lists
+      where id = '70000000-0000-4000-8000-000000000001')
+      <> '60000000-0000-4000-8000-000000000001' then
+    raise exception 'FAIL: A could not attach a location to A''s own personal list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 2 — a household member who is NOT the owner attaches a location.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005d","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists
+  set location_id = '60000000-0000-4000-8000-000000000001'
+  where id = '70000000-0000-4000-8000-000000000002';
+
+  if (select location_id from public.lists
+      where id = '70000000-0000-4000-8000-000000000002')
+      <> '60000000-0000-4000-8000-000000000001' then
+    raise exception 'FAIL: D (household member, not owner) could not attach a location to A''s household list — equal-rank invariant broken';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — D, a household mate of A, cannot reach A's PERSONAL list.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005d","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists
+  set location_id = null
+  where id = '70000000-0000-4000-8000-000000000001';
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select location_id from public.lists
+      where id = '70000000-0000-4000-8000-000000000001')
+      <> '60000000-0000-4000-8000-000000000001' then
+    raise exception 'FAIL: D changed A''s personal list''s location_id — D can reach a list outside their household';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 4 — B, a stranger to both A and D, cannot reach either list.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005b","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists set location_id = null
+  where id = '70000000-0000-4000-8000-000000000001';
+
+  update public.lists set location_id = null
+  where id = '70000000-0000-4000-8000-000000000002';
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select location_id from public.lists
+      where id = '70000000-0000-4000-8000-000000000001')
+      <> '60000000-0000-4000-8000-000000000001' then
+    raise exception 'FAIL: B changed A''s personal list''s location_id — a stranger reached a personal list';
+  end if;
+
+  if (select location_id from public.lists
+      where id = '70000000-0000-4000-8000-000000000002')
+      <> '60000000-0000-4000-8000-000000000001' then
+    raise exception 'FAIL: B changed A''s household list''s location_id — a stranger reached a household list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 5 — the foreign key does real work.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    update public.lists
+    set location_id = '99999999-0000-4000-8000-000000000000'
+    where id = '70000000-0000-4000-8000-000000000001';
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: attaching a nonexistent location_id succeeded — the foreign key constraint is not enforced';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 6 — the household-private/location-global boundary.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000005b","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.locations
+      where id = '60000000-0000-4000-8000-000000000001') <> 1 then
+    raise exception 'FAIL: B (a stranger) cannot see the location A attached — public.locations is no longer global';
+  end if;
+end $$;
+
+reset role;
+
+rollback;


### PR DESCRIPTION
Closes #5.

## Scope
Attach a list to a location and enter a live check-off shopping view — the list ↔ location association and shop-in-progress flow, end to end. No ordering logic (that's Slice 7).

## Schema
One nullable FK: `lists.location_id → locations.id`, `on delete set null`. No `shop_sessions` table — that's Slice 7/9 territory; "closed and resumed without losing check-off state" is already satisfied by `list_items.checked_at` (Slice 2), which already persists and `useListItems` already reloads fresh on every mount. No RPC — a plain column UPDATE, matching the Slice 2 default (existing RLS already covers the column; the FK enforces the location exists).

## UI
- `ListDetailScreen` gets an "Attach a location" / "Shopping at `<name>`" + Start shopping / Change location / Remove location block.
- `LocationsScreen`'s previously-inert "Selected" badge (built in Slice 4 as this slice's hook) now writes the attachment when reached with an `attachToListId` param, through one `handleSelect` function so the attach-vs-badge branch lives in exactly one place. Byte-identical behavior when reached without that param.
- New `ShoppingScreen`: oversized check-off rows (`CheckTarget` gained optional `size`/`label` props rather than a parallel component), per-item pending state so check-off doesn't serialize row to row.

## Bug fix (found in live verification, not pre-planned)
`ListDetailScreen` stays mounted underneath when navigating to `ShoppingScreen`, so two `useListItems` instances for the same list collided on the bare `list-items:<id>` Realtime channel topic — supabase-js returns the same channel object for a repeated topic, and a second `.on()` on an already-subscribed channel throws. Slice 3's hook comment had flagged this as theoretically possible but unreachable; this slice made it reachable. Fixed by suffixing the topic with a per-instance `useId()`.

## Testing checklist (issue #5)
- [x] A list attached to a location opens in shopping mode
- [x] Checked-off items persist immediately
- [x] Session can be closed and resumed without losing check-off state

## Verification
- Migration applied and confirmed live via Supabase MCP.
- `supabase/tests/rls_lists_locations.sql` — 6 assertions + positive control, passes silently.
- `npx tsc --noEmit` — clean.
- Full manual walkthrough on `expo start --web`: attach → shop → check off → confirmed `checked_at` persisted in the database independent of the UI → navigate away/back → cold reload of `/shop/:listId` → detach → re-attach via row-tap. All behaved as expected. Test data cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)