### PR TITLE
Slice 6: Crowdsourced Location Tagging

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,6 +12,9 @@
 - **Next up: Slice 6 — Crowdsourced Location Tagging, issue #6** (was blocked
   on #5, now unblocked).
 - Not yet started; no Investigator/Planner work done for it this session.
+- **Before Slice 6 started, fixed a real blocker: production required a new
+  household on every push.** Root cause and fix are recorded under Decisions
+  below — not a code bug, a Vercel project setting.
 
 ## Notes for next session
 
@@ -21,9 +24,16 @@
   it is woken from the dashboard. Anonymous sign-ins are enabled.
 - Vercel project `cartel` (mp3anthony's projects, Hobby) builds from `main` for
   production and from any pushed branch for a preview. Root Directory `mobile`,
-  build/output from `mobile/vercel.json`. Preview deployments sit behind Vercel's
-  own auth — use the Vercel MCP's `get_access_to_vercel_url` for a 23-hour
-  shareable link rather than assuming a bare preview URL loads.
+  build/output from `mobile/vercel.json`. **Production is public, no auth wall**
+  — reach it at the stable alias `cartel-kappa.vercel.app` (or
+  `cartel-mp3anthonys-projects.vercel.app`; both point at whatever is currently
+  live in production and never change). Preview deployments (any non-`main`
+  branch) still sit behind Vercel's own SSO — use the Vercel MCP's
+  `get_access_to_vercel_url` for a 23-hour shareable link for those, rather
+  than assuming a bare preview URL loads. Deployment Protection is scoped to
+  `preview` only (Vercel project setting, not code) — see Decisions below for
+  why this matters and don't re-tighten it to `all` without re-reading that
+  entry first.
 - Repo was recreated fresh; old sync-engine history was deliberately left behind.
   `origin/main` is always the real `main` if a stale local branch ever disagrees.
 - `.claude/launch.json` (new this slice) runs the web preview on port 8082, not
@@ -31,6 +41,31 @@
   8082 going forward rather than assuming the default.
 
 **Decisions that will look like mistakes if you don't know why**
+- **Vercel Deployment Protection is scoped to `preview`, not `all` — flipped
+  this session, before Slice 6.** The symptom reported was "I have to create a
+  new household every time a new version is pushed to main." The identity
+  model (`mobile/src/lib/supabase.ts`, `useAnonymousSession.ts`) was never
+  broken — anonymous auth persisted to `localStorage` is *designed* to survive
+  restarts, and does. The real cause: the project had no custom domain, and
+  `ssoProtection.deploymentType` was `all_except_custom_domains` — meaning
+  *every* URL the project has, production included, sat behind Vercel's own
+  SSO gate. There was no stable, unauthenticated origin for the app to persist
+  `localStorage` against. Whoever opened it — via a fresh
+  `get_access_to_vercel_url` bypass link pointed at the latest deployment's
+  unique per-push subdomain (`cartel-<hash>-mp3anthonys-projects.vercel.app`,
+  which changes on every deploy by construction) — got a brand-new origin each
+  time, hence a brand-new anonymous session, hence no household. Fixed by
+  setting `ssoProtection.deploymentType: "preview"` via the Vercel MCP's
+  `update_project_deployment_protection` — production is now public at the
+  two stable `*-mp3anthonys-projects.vercel.app` aliases, previews stay
+  gated. Confirmed live: same anonymous `sub` claim across repeated reloads of
+  `cartel-kappa.vercel.app` in a fresh browser profile. This also incidentally
+  fixed a bigger latent gap — before this, no household member other than the
+  Vercel account owner could reach the app at all, which contradicts the
+  CRD's explicit no-login-wall intent. Don't re-enable protection on
+  production without solving the origin-stability problem some other way
+  first (e.g. a custom domain, which is exempt from SSO regardless of this
+  setting).
 - **Realtime is enabled per-table via publication membership, not per-row.**
   Migration `20260810000004` adds `lists`/`list_items` to the `supabase_realtime`
   publication — Slice 2 already wrote both tables' RLS with Realtime's
@@ -200,6 +235,15 @@
   `dispatchEvent(new Event('input', {bubbles:true}))` rather than retrying
   `type` blindly (React-controlled inputs ignore a plain `.value =`
   assignment without the setter/event combo).
+- **One-off "JWT issued at future" error, seen once, unresolved.** Immediately
+  after flipping Deployment Protection this session, the very first cold load
+  of `cartel-kappa.vercel.app` in a fresh browser profile threw this on the
+  initial anonymous sign-in; a plain reload succeeded and the same session
+  persisted cleanly across several more reloads afterward. Browser clock was
+  confirmed correct (matched real time) at the point of the error, so it
+  wasn't ordinary client/server clock skew. Not chased further since it
+  didn't recur — flagging in case it shows up again for someone else's first
+  visit to a newly-public origin.
 - There is still no test harness beyond SQL run via the Supabase MCP's
   `execute_sql` against the hosted project (no local CLI, no `config.toml`, no
   Docker). Each call commits in its own transaction regardless of an open

--- a/mobile/src/hooks/useLocationItems.ts
+++ b/mobile/src/hooks/useLocationItems.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { loadLocationItems, type LocationItemRow } from '../lib/locationItems';
+
+export type LocationItemsView =
+  | { status: 'loading' }
+  | { status: 'loaded'; items: LocationItemRow[] }
+  | { status: 'error'; message: string };
+
+/**
+ * The crowdsourced tags recorded for one location, load-on-mount.
+ *
+ * No `postgres_changes` subscription, same reasoning as `useLocations`: there is
+ * no live-sync acceptance test for this slice (03-SPEC.md's acceptance test reads
+ * as satisfied by a fresh load, "shopping the same location for the first time"),
+ * and `public.location_items` was never added to the `supabase_realtime`
+ * publication in the first place (migration 20260811000000) — the table-level
+ * plumbing a subscription would need isn't there to begin with. `refresh()` is
+ * how a caller picks up a tag it just wrote, same as `useLocations.refresh()`
+ * picks up a location it just created.
+ *
+ * `locationId` is nullable, unlike every other id-keyed hook's parameter
+ * (`useListItems`'s `listId`, `useLocations` takes none). It comes from
+ * `list?.locationId`, and `list` itself comes from the *loaded* `lists` index —
+ * a value that may not have resolved yet when `ShoppingScreen` mounts on a cold
+ * deep link, the same reachable case `ListDetailScreen` already guards against
+ * explicitly before it ever reads `list.locationId`. Rather than push a second
+ * loading gate onto every call site, this hook accepts the not-yet-known state
+ * directly: null means "don't query yet," reported back as `status: 'loading'`
+ * for as long as it holds, so a caller need only pass `list?.locationId ?? null`
+ * unconditionally and let this hook's own status union do the rest.
+ */
+export function useLocationItems(client: SupabaseClient, locationId: string | null) {
+  const [view, setView] = useState<LocationItemsView>({ status: 'loading' });
+  const active = useRef(true);
+
+  // Declared before the loading effect so its cleanup runs first on unmount.
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (locationId === null) {
+      return;
+    }
+    const outcome = await loadLocationItems(client, locationId);
+    if (!active.current) {
+      return;
+    }
+    setView(
+      outcome.ok
+        ? { status: 'loaded', items: outcome.value }
+        : { status: 'error', message: outcome.message },
+    );
+  }, [client, locationId]);
+
+  useEffect(() => {
+    if (locationId === null) {
+      setView({ status: 'loading' });
+      return;
+    }
+    setView({ status: 'loading' });
+    refresh();
+  }, [locationId, refresh]);
+
+  return { view, refresh };
+}

--- a/mobile/src/lib/locationItems.ts
+++ b/mobile/src/lib/locationItems.ts
@@ -1,0 +1,126 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { humanise, type Outcome } from './household';
+
+/**
+ * One crowdsourced tag: an item name, normalized, paired with the section a
+ * shopper found it in at one location. `id`/`createdAt` are the row's own
+ * identity and timestamp — there is no creator field anywhere on this type,
+ * because there is none on the table it comes from (migration 20260811000000):
+ * `public.location_items` collects section text, never who left it.
+ */
+export type LocationItemRow = {
+  id: string;
+  name: string;
+  section: string;
+  createdAt: string;
+};
+
+/**
+ * The database's spelling of the row above, kept separate rather than exported so
+ * that snake_case stops at this file. `location_id` is deliberately absent — every
+ * caller of `loadLocationItems` already scopes the query to one location, so
+ * echoing that id back on every row would be redundant, not informative.
+ */
+type LocationItemRecord = {
+  id: string;
+  name: string;
+  section: string;
+  created_at: string;
+};
+
+/**
+ * Trims and lowercases an item name into the form `location_items.name` is
+ * stored in and matched against. The one call site for this transform, so
+ * "what counts as the same item" is decided once rather than re-derived by
+ * every caller that needs to compare a typed name against a stored one.
+ */
+export function normalizeItemName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/**
+ * Looks up the section a list item's name has already been tagged with at a
+ * location, or null if nobody has tagged it there yet.
+ *
+ * A linear scan, not a `Map`, because callers hold this per-screen, per-render —
+ * `ShoppingScreen` calls it once per visible item — and a location's tag count is
+ * the same order of magnitude as its list's item count, tens not thousands.
+ * Building and memoizing a `Map` would be a second cache to keep in sync with
+ * `items` for a lookup cost that was never the bottleneck.
+ */
+export function sectionForItemName(
+  items: readonly LocationItemRow[],
+  itemName: string,
+): string | null {
+  const key = normalizeItemName(itemName);
+  return items.find((item) => item.name === key)?.section ?? null;
+}
+
+/**
+ * All tags recorded for one location, in no particular order — callers look a
+ * single name up via `sectionForItemName` rather than reading this list in
+ * sequence, so there is nothing an ordering would buy.
+ */
+export async function loadLocationItems(
+  client: SupabaseClient,
+  locationId: string,
+): Promise<Outcome<LocationItemRow[]>> {
+  const { data, error } = await client
+    .from('location_items')
+    .select('id, name, section, created_at')
+    .eq('location_id', locationId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as LocationItemRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      section: row.section,
+      createdAt: row.created_at,
+    })),
+  };
+}
+
+/**
+ * Records that an item lives in a given section at a location.
+ *
+ * A bare `INSERT`, not `.upsert()` and not an insert-then-select fallback. The
+ * table's `unique (location_id, name)` constraint (migration 20260811000000) is
+ * the only arbitration this slice has for two shoppers racing to tag the same
+ * not-yet-tagged item with different section text — first write wins. `.upsert()`
+ * would make the second, losing writer overwrite the first writer's section
+ * silently, which is exactly the outcome the unique constraint exists to prevent.
+ * An insert-then-select fallback would work, but costs a second round trip on
+ * every race for a result the caller does not need: the caller's own `refresh()`
+ * after this call returns already reloads the section text from the database,
+ * whichever writer actually won.
+ *
+ * A `23505` (unique-violation) error is therefore treated as success, not
+ * failure — the item is tagged, just not necessarily with this caller's section
+ * text, and there is nothing more useful to tell them than that.
+ */
+export async function tagItemLocation(
+  client: SupabaseClient,
+  locationId: string,
+  itemName: string,
+  section: string,
+): Promise<Outcome<void>> {
+  const { error } = await client.from('location_items').insert({
+    location_id: locationId,
+    name: normalizeItemName(itemName),
+    section: section.trim(),
+  });
+
+  if (error && error.code !== '23505') {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -1,21 +1,29 @@
-import { useLayoutEffect, useState } from 'react';
-import { ActivityIndicator } from 'react-native';
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
+  Badge,
   Body,
   CheckTarget,
   EmptyState,
   ErrorNote,
+  Field,
+  IconButton,
   NAVIGATOR_EDGES,
+  PrimaryButton,
   Screen,
+  SecondaryButton,
 } from '../components/ui';
 import { useListItems } from '../hooks/useListItems';
 import type { ListsView } from '../hooks/useLists';
+import { useLocationItems } from '../hooks/useLocationItems';
+import { sectionForItemName, tagItemLocation } from '../lib/locationItems';
 import { setChecked, type ListItemRow } from '../lib/lists';
 import type { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../theme/ThemeProvider';
+import type { Tokens } from '../theme/tokens';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
   client: SupabaseClient;
@@ -32,7 +40,11 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * round trip for no reason. The `Set` only guards a row against racing itself — a
  * second tap on the *same* item before its first write lands — which is the one
  * case double-firing would actually corrupt (two in-flight writes toggling the same
- * `checked_at` back and forth). Different rows are free to be in flight together.
+ * `checked_at` back and forth, or double-submitting the same tag). Different rows
+ * are free to be in flight together. Slice 6 reuses this same `pending` Set for a
+ * tag-submit write too, rather than adding a second Set: both a check-off write and
+ * a tag-submit write are "this item's row has a write in flight," the same fact
+ * the Set already tracks.
  *
  * "Closed and resumed without losing check-off state" needs no new mechanism here.
  * `toggle()` awaits `setChecked()` before calling `refresh()`, so the UI only ever
@@ -45,21 +57,42 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * back whatever `checked_at` is currently stored. There is no `shop_sessions` row
  * to resume and nothing here to reconstruct.
  *
- * No reordering, grouping, or "Finish shopping" button — out of scope per this
- * slice's plan: items render in whatever order `useListItems` returns, unchanged,
- * and there is no session row to finalize.
+ * No reordering, grouping, or "Finish shopping" button — out of scope per Slice 5's
+ * plan: items render in whatever order `useListItems` returns, unchanged, and there
+ * is no session row to finalize.
+ *
+ * Slice 6 adds crowdsourced section tagging alongside check-off, one control per
+ * item beneath its `CheckTarget` row rather than folded into it — `CheckTarget`'s
+ * own doc comment already names the "two nested Pressables reacting to one tap"
+ * anti-pattern this avoids by keeping the two controls as siblings. A tagged item
+ * shows its section as a `Badge`; an untagged one shows a `+` that opens a small
+ * inline composer for this row only (`composingItemId`) rather than a modal or a
+ * second screen, matching the low-friction, walking-through-the-store spirit the
+ * rest of this screen already has.
  */
 export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
   const { listId } = route.params;
   const { view, refresh } = useListItems(client, listId);
-  const [pending, setPending] = useState<Set<string>>(new Set());
-  const [error, setError] = useState<string | null>(null);
 
+  // Computed here, not a hook itself, so the hook call below it (which depends on
+  // `list.locationId`) can stay in the same, unconditional position on every
+  // render — never behind one of this screen's own early returns further down.
   const list =
     lists.status === 'loaded'
       ? lists.lists.find((candidate) => candidate.id === listId) ?? null
       : null;
+
+  const { view: locationItems, refresh: refreshLocationItems } = useLocationItems(
+    client,
+    list?.locationId ?? null,
+  );
+
+  const [pending, setPending] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [composingItemId, setComposingItemId] = useState<string | null>(null);
+  const [sectionDraft, setSectionDraft] = useState('');
 
   useLayoutEffect(() => {
     // Same reasoning as ListDetailScreen's header: it carries the list's name, and
@@ -86,6 +119,52 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
       }
 
       await refresh();
+    } finally {
+      setPending((current) => {
+        const next = new Set(current);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  }
+
+  function beginTagging(itemId: string) {
+    setError(null);
+    setComposingItemId(itemId);
+    setSectionDraft('');
+  }
+
+  function cancelTagging() {
+    setComposingItemId(null);
+    setSectionDraft('');
+  }
+
+  async function submitTag(item: ListItemRow) {
+    if (!list || list.locationId === null) {
+      return;
+    }
+    if (sectionDraft.trim().length === 0 || pending.has(item.id)) {
+      return;
+    }
+
+    setPending((current) => new Set(current).add(item.id));
+    setError(null);
+
+    try {
+      const outcome = await tagItemLocation(
+        client,
+        list.locationId,
+        item.name,
+        sectionDraft,
+      );
+
+      if (!outcome.ok) {
+        setError(outcome.message);
+        return;
+      }
+
+      await refreshLocationItems();
+      cancelTagging();
     } finally {
       setPending((current) => {
         const next = new Set(current);
@@ -137,7 +216,10 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     );
   }
 
-  if (view.status === 'loading') {
+  // Past this point `list.locationId` is known non-null, so `useLocationItems`
+  // above was called with a real id rather than null — these two gates are safe
+  // to merge with (loading) and mirror (error) the existing view.status ones.
+  if (view.status === 'loading' || locationItems.status === 'loading') {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
         <ActivityIndicator color={tokens.color.accent} size="large" />
@@ -149,6 +231,14 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
         <ErrorNote message={view.message} />
+      </Screen>
+    );
+  }
+
+  if (locationItems.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={locationItems.message} />
       </Screen>
     );
   }
@@ -175,17 +265,77 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
 
       {error ? <ErrorNote message={error} /> : null}
 
-      {items.map((item) => (
-        <CheckTarget
-          key={item.id}
-          size="large"
-          label={item.name}
-          checked={item.checkedAt !== null}
-          onToggle={() => void toggle(item)}
-          disabled={pending.has(item.id)}
-          accessibilityLabel={item.name}
-        />
-      ))}
+      {items.map((item) => {
+        const section = sectionForItemName(locationItems.items, item.name);
+        const composing = composingItemId === item.id;
+
+        return (
+          <View key={item.id} style={styles.itemGroup}>
+            <CheckTarget
+              size="large"
+              label={item.name}
+              checked={item.checkedAt !== null}
+              onToggle={() => void toggle(item)}
+              disabled={pending.has(item.id)}
+              accessibilityLabel={item.name}
+            />
+
+            <View style={styles.tagRow}>
+              {section !== null ? (
+                <Badge label={section} />
+              ) : composing ? (
+                <View style={styles.tagComposer}>
+                  <Field
+                    label="Section"
+                    value={sectionDraft}
+                    onChangeText={setSectionDraft}
+                    placeholder="Aisle 4"
+                    autoCapitalize="sentences"
+                    autoFocus
+                    maxLength={60}
+                    editable={!pending.has(item.id)}
+                    onSubmitEditing={() => void submitTag(item)}
+                    returnKeyType="done"
+                  />
+                  <PrimaryButton
+                    label="Save"
+                    onPress={() => void submitTag(item)}
+                    busy={pending.has(item.id)}
+                    disabled={sectionDraft.trim().length === 0}
+                  />
+                  <SecondaryButton
+                    label="Cancel"
+                    onPress={cancelTagging}
+                    disabled={pending.has(item.id)}
+                  />
+                </View>
+              ) : (
+                <IconButton
+                  glyph="+"
+                  accessibilityLabel={`Tag a section for ${item.name}`}
+                  onPress={() => beginTagging(item.id)}
+                />
+              )}
+            </View>
+          </View>
+        );
+      })}
     </Screen>
   );
+}
+
+function createStyles(tokens: Tokens) {
+  return StyleSheet.create({
+    itemGroup: {
+      gap: tokens.space.xs,
+    },
+    tagRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingLeft: tokens.minTouchTargetLarge,
+    },
+    tagComposer: {
+      gap: tokens.space.sm,
+    },
+  });
 }

--- a/supabase/migrations/20260811000000_location_items.sql
+++ b/supabase/migrations/20260811000000_location_items.sql
@@ -1,0 +1,104 @@
+-- Slice 6 — Crowdsourced Location Tagging.
+--
+-- `public.location_items` is global and anonymous, exactly like `public.locations`
+-- (migration 20260810000005) and for the same reason: 03-SPEC.md § 0 treats
+-- location data and household data as two classes that must never share an
+-- access-control path. There is no household_id, no owner_id, and — unlike
+-- `locations.created_by` — no creator column of any kind, not even one withheld
+-- from the SELECT grant. Nothing in this slice, Slice 7 (route ordering reads
+-- accumulated tags, never who left them), or Slice 8 (its own
+-- `location_item_votes` table owns supporter-id tracking, a separate concern from
+-- this one) ever reads a creator off this table. A stored-then-withheld column is
+-- "we chose not to show this"; no column at all is "this was never collected" —
+-- the stronger of the two claims the issue's "not attributable ... anywhere in ...
+-- data" actually asks for, and this repo's stated philosophy (see HANDOFF's
+-- `shop_sessions` reasoning, Slice 5) is no schema nobody reads.
+--
+-- `name` is the matching key: `list_items.name` as a shopper typed it, trimmed and
+-- lowercased. `list_items.name` itself stays free-text and case-preserved (Slice
+-- 2's choice, unchanged here) — normalization has to happen somewhere for two
+-- shoppers' "Milk", "milk ", "MILK" to ever hit the same row, and it happens once,
+-- here, enforced by a check constraint rather than trusted to every future insert
+-- to remember. This is a stricter rule than `lists.name`/`locations.name` get
+-- (which only bound trimmed *length*, not stored form — see migration
+-- 20260810000003/000005) because those are display-only text; this column is a
+-- lookup key whose entire job depends on two independently-normalized inputs
+-- landing on the same string. `section`, by contrast, IS display-only (shown to a
+-- shopper as-is), so it gets the ordinary trimmed-length check and nothing more —
+-- same asymmetry as every other text column in this schema, just applied to two
+-- columns with different jobs on one table.
+--
+-- `unique (location_id, name)` is the whole of this slice's concurrency story.
+-- Two different households' shoppers can race to tag the same untagged item at
+-- the same location with different section text; there is no correction/voting
+-- mechanism yet (that's Slice 8's `location_item_votes`, not built here), so this
+-- constraint is the only arbiter: first INSERT wins, the second fails with a
+-- unique violation (23505) rather than silently overwriting the winner. The
+-- client-side handling of that failure lives in `mobile/src/lib/locationItems.ts`
+-- (`tagItemLocation`), not here — see that file's doc comment for why a bare
+-- `INSERT` beats both `.upsert()` and an insert-then-select fallback.
+--
+-- No `deleted_at`. Same as `locations` (Slice 4): no removal flow is in scope for
+-- this slice, so there is nothing to soft-delete. Slice 8's correction mechanism,
+-- when it lands, will UPDATE this table's `section` column on an *existing* row in
+-- place — this schema deliberately doesn't paint that into a corner (no
+-- append-only/immutable constraint here), it just doesn't build the update path
+-- yet.
+--
+-- No new row in `supabase_realtime`'s publication membership. `locations` itself
+-- was never added to that publication either (only `lists`/`list_items` were, in
+-- 20260810000004) — this isn't only `useLocations`'s hook-level choice to skip a
+-- subscription, the table-level plumbing for this data class was never turned on
+-- at all. Matched here for the same reason: 03-SPEC.md's acceptance test for this
+-- slice reads as satisfied by a fresh load ("shopping the same location for the
+-- first time"), not live mid-shop push.
+--
+-- No function, no RPC. Same reasoning as migration 20260810000006's header:
+-- writes go direct to table under RLS `with check` unless there's a real
+-- atomicity/authorization invariant RLS can't express. There isn't one here —
+-- "may I insert a tag" is "are you authenticated," a plain check, and "does this
+-- location exist" is exactly what the FK already enforces. The one thing that
+-- looks like it needs a function — arbitrating a race — is instead handled
+-- entirely by the UNIQUE constraint plus ordinary INSERT failure semantics, which
+-- doesn't need RLS or a function to be involved.
+
+create table public.location_items (
+  id uuid primary key default gen_random_uuid(),
+  location_id uuid not null references public.locations (id) on delete cascade,
+  name text not null
+    check (length(name) between 1 and 120)
+    check (name = lower(btrim(name))),
+  section text not null check (length(trim(section)) between 1 and 60),
+  created_at timestamptz not null default now(),
+  unique (location_id, name)
+);
+
+-- No separate index on location_id alone: the unique constraint above already
+-- creates a composite index with location_id as its leading column, which serves
+-- the "all tags for this location" query (`loadLocationItems`) exactly as well as
+-- a dedicated single-column index would, for free.
+
+alter table public.location_items enable row level security;
+
+create policy location_items_select_all on public.location_items
+  for select to authenticated
+  using (true);
+
+-- No creator-pinning check in this policy's `with check` — unlike
+-- `locations_insert_own` (migration 20260810000005), there is no creator column
+-- to pin, because this table doesn't have one. "May I tag an item" has no
+-- predicate beyond "are you authenticated," which the `to authenticated` clause
+-- already establishes.
+create policy location_items_insert_all on public.location_items
+  for insert to authenticated
+  with check (true);
+
+-- No update, no delete policy or grant. Slice 8 will add an UPDATE policy for its
+-- correction mechanism; this slice deliberately doesn't build it early, matching
+-- `locations`' own precedent of shipping with no update/delete story until a slice
+-- actually needs one.
+
+revoke all on table public.location_items from anon, authenticated;
+
+grant select (id, location_id, name, section, created_at) on table public.location_items to authenticated;
+grant insert on table public.location_items to authenticated;

--- a/supabase/tests/rls_location_items.sql
+++ b/supabase/tests/rls_location_items.sql
@@ -1,0 +1,232 @@
+-- RLS/grant tests for public.location_items (Slice 6 — Crowdsourced Location
+-- Tagging).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- WHAT IT IS REALLY GUARDING. `public.location_items` (migration 20260811000000)
+-- is deliberately global and anonymous, same class as `public.locations` per
+-- 03-SPEC.md § 0 — assertion 1 is this file's direct analogue of
+-- rls_locations.sql's assertion 1 and the issue's own acceptance test: a stranger
+-- who shares nothing with the tag's author must still see it. Assertion 2 checks
+-- the stronger anonymity claim structurally, at the schema level, rather than only
+-- behaviourally — there is no creator column to withhold in the first place, not
+-- merely one that is withheld from a grant. Assertion 3 is the race-arbitration
+-- story migration 20260811000000's header describes: `unique (location_id, name)`
+-- is the only thing standing between two shoppers' concurrent tags on the same
+-- untagged item, so this checks both halves — the loser's INSERT actually raises,
+-- and the winner's section text is genuinely undisturbed afterwards, not merely
+-- that an error was thrown. Assertion 4 checks that tagging needs no household at
+-- all, matching `locations_insert_own`'s own "are you authenticated" bar.
+-- Assertions 5-6 check the two check/foreign-key constraints do real enforcement
+-- work rather than being decorative.
+--
+-- Fixtures are the premise, not the thing under test, so the location row is
+-- inserted as the owning role, which bypasses RLS. Only the assertions run as
+-- `authenticated`. `request.jwt.claims` must be set *before* the role switch:
+-- after it, the session no longer has the privilege to set the GUC on some
+-- configurations, and auth.uid() reads that GUC.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. E and F share nothing — no household, no prior relationship. One
+-- location L, created by E for convenience (created_by is not under test here).
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-0000000000e1', true),  -- E
+  ('00000000-0000-4000-8000-0000000000f1', true);  -- F
+
+insert into public.locations (id, name, lat, lng, created_by) values
+  ('80000000-0000-4000-8000-000000000001',
+   'Test Supermarket', -36.8485, 174.7633,
+   '00000000-0000-4000-8000-0000000000e1');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control, as E. Without this, the "must be visible"
+-- assertions below would prove nothing if the policy hid everything, including
+-- from the row's own author.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  insert into public.location_items (location_id, name, section)
+  values ('80000000-0000-4000-8000-000000000001', 'milk', 'Aisle 3');
+
+  if (select count(*) from public.location_items
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 1 then
+    raise exception 'FAIL: E cannot see the tag E just inserted';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — THE core property. As F, who shares no household with E and did
+-- not create the row: E's tag must still be visible on a plain select scoped to
+-- location L. This is the direct analogue of the issue's acceptance test.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select section from public.location_items
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 3' then
+    raise exception 'FAIL: F cannot see E''s tag — location_items is not actually global (it is scoping visibility by author or household when it must not, or should never have had one to begin with)';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 2 — anonymity, structurally. No column on this table can name a
+-- creator, not merely one withheld from a grant. Metadata query, no role switch
+-- needed.
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'location_items'
+      and column_name in ('created_by', 'user_id', 'owner_id', 'tagged_by', 'author_id')
+  ) then
+    raise exception 'FAIL: public.location_items has a creator-shaped column — this table must never attribute a tag to anyone';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — insert-race / first-tag-wins. As F, attempting to tag the same
+-- (location, normalized name) E already tagged must raise (the unique
+-- constraint), and E's stored section must be left completely undisturbed.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_items (location_id, name, section)
+    values ('80000000-0000-4000-8000-000000000001', 'milk', 'Aisle 7');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: F''s racing insert for the same (location, name) succeeded — the unique constraint is not arbitrating the race';
+  end if;
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select section from public.location_items
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 3' then
+    raise exception 'FAIL: E''s winning section was overwritten by F''s losing insert — first-tag-wins is broken';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 4 — no household required to write. As F, who has no household at
+-- all, inserting a new, different tag at L must succeed and be visible.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  insert into public.location_items (location_id, name, section)
+  values ('80000000-0000-4000-8000-000000000001', 'bread', 'Aisle 1');
+
+  if (select count(*) from public.location_items
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and name = 'bread') <> 1 then
+    raise exception 'FAIL: F (no household at all) could not tag an item, or cannot see the tag F just inserted';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 5 — the foreign key does real work.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_items (location_id, name, section)
+    values ('99999999-0000-4000-8000-000000000000', 'eggs', 'Aisle 2');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: inserting a tag against a nonexistent location_id succeeded — the foreign key constraint is not enforced';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 6 — the normalization check constraint does real work. A
+-- not-yet-used name inserted with capitals must be rejected, not silently
+-- stored or silently lowercased.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_items (location_id, name, section)
+    values ('80000000-0000-4000-8000-000000000001', 'Milk', 'Aisle 9');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: an uppercase name was accepted — the name = lower(btrim(name)) check constraint is not enforced';
+  end if;
+end $$;
+
+reset role;
+
+rollback;


### PR DESCRIPTION
Closes #6.

## Scope
While shopping, a user can tag an item with its shelf/section at the current
location if it isn't tagged yet. Tags are anonymous (no creator column at all
on `location_items` — stronger than `locations.created_by`'s store-then-withhold
pattern) and attach to the location, not the household.

## What changed
- `supabase/migrations/20260811000000_location_items.sql` — new `public.location_items`
  table: global/anonymous, `unique (location_id, name)` arbitrates concurrent taggers
  (first tag wins; the loser's insert fails with `23505`, treated as success
  client-side since the caller's own reload picks up whichever section won), no
  realtime publication membership (matches `locations`, never live-sync tested).
- `mobile/src/lib/locationItems.ts` — `loadLocationItems`, `tagItemLocation`,
  `sectionForItemName` (live name-match lookup; no stored FK added to `list_items`).
- `mobile/src/hooks/useLocationItems.ts` — load-on-mount per-location tags, no
  subscription, nullable `locationId` (the attached list may not have resolved yet).
- `mobile/src/screens/ShoppingScreen.tsx` — each item gets a sibling tag control
  under its `CheckTarget` (a `Badge` once tagged; an inline `Field` + Save/Cancel
  composer to tag it; a `+` affordance otherwise) — never nested inside
  `CheckTarget`'s own `Pressable`.
- `supabase/tests/rls_location_items.sql` — 7 assertions, run clean against the
  live project.

## Testing checklist (from #6) — all verified live this session
- [x] User A tags an item's location during a shop — done live via
      `ShoppingScreen`'s composer (real Browser-pane session, real anonymous
      user) and by `rls_location_items.sql` assertion 0.
- [x] A completely unrelated household (no shared membership with A) shopping
      the same location for the first time sees that tag on their own list —
      verified live with two genuinely distinct anonymous users (confirmed
      differing `auth.uid()`s) in two separate browser profiles: user B, no
      household, never tagged anything, attached a different list's "milk"
      (lowercase, proving the name-normalization match) to the same location
      by search, and saw "Dairy Aisle 3" the instant Shopping Mode loaded.
      `rls_location_items.sql` assertion 1 covers the same property at the
      RLS level.
- [x] Tag is not attributable to A anywhere in the UI or data returned to
      other users — `location_items` has no creator column at all (assertion
      2 checks this structurally), `ShoppingScreen` never renders one, and
      `read_network_requests` confirmed the live `location_items` fetch's
      `select=` query string names only `id,name,section,created_at`.

Test rows cleaned up after verification (scoped, id-by-id — production now
holds a real household from genuine use, so the old blanket-wipe cleanup
query was retired; see HANDOFF.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)