### PR TITLE
Slice 7 — Route Learning & Auto-Ordering

### DIFF
--- a/03-SPEC.md
+++ b/03-SPEC.md
@@ -279,6 +279,52 @@ more tags/history — no fixed accuracy target, but the ordering must visibly ch
 entry/arbitrary order; the same location after several shops with location tags
 present produces a stable, repeatable non-arbitrary order for the same item set.
 
+*Agreed 2026-08-11, at Protocol Step 2 — the issue's own `ready-for-human` label
+was correct: neither `01-CRD.md` nor `02-DESIGN-REFERENCE.md` says how tags and
+observed check-off order combine into a route, and none of it was inferable from
+existing code or convention:*
+
+- **No `shop_sessions` table as `§1`'s aspirational schema sketches it — a new,
+  anonymous, location-scoped table instead**, named `location_checkoffs`
+  (mirrors `location_items`' naming). One row per completed shop: `location_id`,
+  an ordered array of normalized item names actually checked during that shop,
+  `completed_at`. No `household_id`, `list_id`, or user attribution of any
+  kind — same reasoning `location_items` already established in Slice 6
+  (stronger than store-and-withhold), and required here because `§0` forbids
+  location-global and household-private data from ever sharing an
+  access-control path. `shop_sessions` as CRD-sketched — a household-attributed
+  list snapshot feeding household-facing history — mixes both, and gets built
+  separately, as its own table, whenever Slice 9 actually needs it. Not built
+  ahead of that slice.
+- **Ordering is observed-order-primary.** For a list opening at a location: an
+  item with its own prior check-off history at this location sorts by its mean
+  historical position (averaged across every `location_checkoffs` row at that
+  location whose array contains it). An item with no check-off history of its
+  own but a known `location_items` tag falls back to that section's mean
+  position (mean position, across the same history, of every *other* item
+  sharing that section text). An item with neither signal — including every
+  item at a location with zero history — keeps its original entry order,
+  appended after every item that resolved a position. This is why zero-history
+  locations produce entry order for free, satisfying the acceptance test's
+  first bullet without a special case.
+- **The mean is a plain arithmetic mean of positional index**, not a weighted
+  or recency-biased average. Simplest thing that satisfies "quality improves as
+  data accumulates, no fixed accuracy target" — revisit only if live use shows
+  a concrete failure this can't explain.
+- **Sorting happens at read time in `ShoppingScreen` only, and never writes
+  `position`.** Already locked by Slice 2's own Agreed block above ("Route
+  order is a property of list × location, computed as a sort at read time");
+  Slice 7 doesn't reopen it. `ListDetailScreen`'s manual order is unaffected —
+  route order is a `ShoppingScreen`-only presentation, matching Slice 5/6's
+  precedent that shopping-specific behavior lives there, not in the shared
+  detail screen.
+- **A new "Finish shopping" action in `ShoppingScreen` writes the
+  `location_checkoffs` row** — snapshotting whatever's checked, in check-off
+  order, the moment it's pressed. It does not reset `checked_at` or touch list
+  reuse across weeks; that's Slice 9 territory and stays out, matching this
+  project's habit (§5/§6's `shop_sessions` deferral, `locations`' no-demotion
+  precedent) of not building ahead of the slice that actually needs it.
+
 ### Slice 8 — Location Correction Voting
 **Depends on:** Slice 6.
 **Scope:** A user can propose a correction to an existing item-location tag (item

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,6 +5,73 @@
 
 ## Last active
 
+- **Slice 7 — Route Learning & Auto-Ordering — built end-to-end this
+  session, on branch `slice-7-route-learning`, PR not yet opened as of this
+  write-up (opening next).** Closes issue #7.
+  - **Issue #7 had been accidentally auto-closed** by GitHub's keyword
+    detection matching "resolve #7" in a *previous* session's handoff commit
+    message (`93fca49`) — that commit was only about verifying the label's
+    accuracy, not completing the slice. Reopened at the start of this session
+    with an explanatory comment before any real work started. If a future
+    commit message needs to reference an issue number without triggering
+    auto-close, avoid GitHub's close-keyword list ("closes", "fixes",
+    "resolves" + others) immediately before the `#N`.
+  - **Problem Agreement ran properly this time** (Protocol Step 3's
+    escalation trigger — the ordering heuristic was a genuine open question,
+    confirmed by re-reading `01-CRD.md`/`02-DESIGN-REFERENCE.md` and finding
+    no resolution in either) — three real forks put to the user via
+    `AskUserQuestion` before any Investigator/Planner/Code Writer work:
+    (1) a separate anonymous `location_checkoffs` table vs. building the
+    CRD-sketched combined `shop_sessions` table now, (2) observed-order-primary
+    vs. section-grouped-primary vs. tags-only ordering, (3) a new "Finish
+    shopping" button vs. auto-completing on last item checked. All three
+    resolved to the recommended option. Full reasoning recorded in
+    `03-SPEC.md § Slice 7`'s "Agreed 2026-08-11" block — read that before
+    touching this slice's schema or algorithm again, not this file.
+  - **New table `public.location_checkoffs`** (migration
+    `20260811000001`), global and anonymous like `location_items` — no
+    `household_id`/`list_id`/user column at all, `on delete cascade` on
+    `location_id` (matches `location_items`, not `lists.location_id`'s
+    set-null). One row per completed shop: an ordered array of normalized
+    checked item names + `completed_at`. Not added to the realtime
+    publication (matches `location_items`/`locations`).
+  - **`mobile/src/lib/locationCheckoffs.ts`**: `loadLocationCheckoffs`,
+    `recordLocationCheckoff`, `orderedCheckedItemNames`, and the three-tier
+    `computeRouteOrder` (own history → section-tag fallback → entry order) —
+    doc comments walk through the algorithm in full. `mobile/src/hooks/useLocationCheckoffs.ts`
+    mirrors `useLocationItems.ts` field-for-field.
+  - **`ShoppingScreen.tsx`** now renders `computeRouteOrder`'s output instead
+    of `useListItems`'s raw order (read-time sort only — `position` is still
+    never written, per Slice 2's already-locked decision) and gained a new
+    confirm-gated "Finish shopping" `SecondaryButton` that writes one
+    `location_checkoffs` row from whatever's currently checked. Doesn't reset
+    `checked_at` or touch list reuse across weeks — deliberately out of
+    scope, stays Slice 9's.
+  - **Both acceptance-test bullets live-verified** against a local dev
+    session (`npx expo start --web`, port 8082) rather than production — the
+    Vercel preview/prod origins all point at the same live Supabase project,
+    and production now holds a real household's data (see Traps below), so
+    all test writes went through local dev instead. Verified beyond the
+    minimum: a zero-history location rendered a fresh list in exact entry
+    order; the same location after two recorded shops (checked
+    eggs→bread→milk→apples both times) rendered a *new* list with a
+    *different* entry order (apples→milk→bread→eggs) back in the observed
+    eggs→bread→milk→apples order, reproduced identically after a full cold
+    reload. Additionally isolated and confirmed the section-tag fallback
+    tier specifically: an item ("yogurt") tagged with the same section as an
+    already-observed item ("milk") but never itself checked at that location
+    slotted in at milk's own mean position, tie-broken by entry order — and
+    confirmed the true-zero-signal tier separately (untagged, unchecked
+    "yogurt" sorted last before it was tagged). All test rows (1 location, 2
+    lists, 2 checkoff rows, 2 location_items tags, 1 anonymous user) queried
+    and confirmed as this session's own before deletion, then deleted and
+    reverified at zero — see the corrected cleanup practice in Traps below,
+    followed correctly here.
+  - `npx tsc --noEmit` clean. `supabase/tests/rls_location_checkoffs.sql` (8
+    assertions, positive control + cross-household visibility + structural
+    anonymity + no-household-required-to-write + FK enforcement + cascade
+    delete + both check constraints) ran clean against the live project.
+  - `mobile/app.json` and `mobile/package.json` bumped to `0.0.7`.
 - **Slice 6 is done and merged.** [PR #17](https://github.com/mp3anthony/cartel/pull/17)
   merged to `main`, closing issue #6. Feature branch deleted, both locally and
   on origin.
@@ -37,10 +104,15 @@
   same as before. Merged directly this session (user confirmed the
   go-ahead) rather than left for later, specifically so the live-environment
   verification above could happen rather than being deferred again.
-- **Next up: Slice 7 — Route Learning & Auto-Ordering, issue #7**
-  (depends on Slice 6, now actually unblocked — merged, not just built). See
-  the Loose Ends entry below on #7's label before trusting it either way.
-  Not yet started; no Investigator/Planner work done for it.
+- **Next up: Slice 8 — Location Correction Voting, issue #8** (depends on
+  Slice 6, already merged — no blocker) or Slice 9 — Shop History & List
+  Templates, issue #9 (depends on Slice 5, already merged). Both are
+  labelled `ready-for-agent`; neither has had Investigator/Planner work done.
+  Slice 9 is the slice that finally needs a real, household-attributed
+  `shop_sessions` table (see this session's Slice 7 entry above for why that
+  was deliberately *not* built there) — start Slice 9 by re-reading that
+  reasoning rather than assuming the new `location_checkoffs` table is reusable
+  for it; it structurally can't be (no household/list attribution by design).
 - Full Investigator→Planner→Code Writer cycle run via subagents this session
   (no Problem Agreement round — issue was ready-for-agent and no genuinely
   open question came up). New `public.location_items` table (migration

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,8 +6,11 @@
 ## Last active
 
 - **Slice 7 — Route Learning & Auto-Ordering — built end-to-end this
-  session, on branch `slice-7-route-learning`, PR not yet opened as of this
-  write-up (opening next).** Closes issue #7.
+  session, on branch `slice-7-route-learning`.
+  [PR #19](https://github.com/mp3anthony/cartel/pull/19) open, awaiting
+  review — not merged yet, matching the standing pattern of not merging
+  without the user's go-ahead (see PR #18's entry above for the one
+  deliberate exception).** Closes issue #7 once merged.
   - **Issue #7 had been accidentally auto-closed** by GitHub's keyword
     detection matching "resolve #7" in a *previous* session's handoff commit
     message (`93fca49`) — that commit was only about verifying the label's

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/hooks/useLocationCheckoffs.ts
+++ b/mobile/src/hooks/useLocationCheckoffs.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { loadLocationCheckoffs, type LocationCheckoffRow } from '../lib/locationCheckoffs';
+
+export type LocationCheckoffsView =
+  | { status: 'loading' }
+  | { status: 'loaded'; checkoffs: LocationCheckoffRow[] }
+  | { status: 'error'; message: string };
+
+/**
+ * The completed-shop history recorded for one location, load-on-mount.
+ *
+ * No `postgres_changes` subscription, same reasoning as `useLocationItems`:
+ * there is no live-sync acceptance test for this slice (03-SPEC.md's
+ * acceptance test reads as satisfied by a fresh load — a location
+ * accumulating history across separate completed shops, not live mid-shop
+ * push), and `public.location_checkoffs` was never added to the
+ * `supabase_realtime` publication in the first place (migration
+ * 20260811000001) — the table-level plumbing a subscription would need isn't
+ * there to begin with. `refresh()` is how a caller picks up a shop it just
+ * recorded, same as `useLocationItems.refresh()` picks up a tag it just
+ * wrote.
+ *
+ * `locationId` is nullable, matching `useLocationItems`'s own contract: it
+ * comes from `list?.locationId`, which may not have resolved yet when
+ * `ShoppingScreen` mounts on a cold deep link. Null means "don't query yet,"
+ * reported back as `status: 'loading'` for as long as it holds, so a caller
+ * need only pass `list?.locationId ?? null` unconditionally and let this
+ * hook's own status union do the rest.
+ */
+export function useLocationCheckoffs(client: SupabaseClient, locationId: string | null) {
+  const [view, setView] = useState<LocationCheckoffsView>({ status: 'loading' });
+  const active = useRef(true);
+
+  // Declared before the loading effect so its cleanup runs first on unmount.
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (locationId === null) {
+      return;
+    }
+    const outcome = await loadLocationCheckoffs(client, locationId);
+    if (!active.current) {
+      return;
+    }
+    setView(
+      outcome.ok
+        ? { status: 'loaded', checkoffs: outcome.value }
+        : { status: 'error', message: outcome.message },
+    );
+  }, [client, locationId]);
+
+  useEffect(() => {
+    if (locationId === null) {
+      setView({ status: 'loading' });
+      return;
+    }
+    setView({ status: 'loading' });
+    refresh();
+  }, [locationId, refresh]);
+
+  return { view, refresh };
+}

--- a/mobile/src/lib/locationCheckoffs.ts
+++ b/mobile/src/lib/locationCheckoffs.ts
@@ -1,0 +1,211 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { humanise, type Outcome } from './household';
+import { normalizeItemName, type LocationItemRow } from './locationItems';
+
+/**
+ * One completed shop at a location: the normalized item names checked off,
+ * in the order they were checked, paired with when the shop finished.
+ * `id`/`completedAt` are the row's own identity and timestamp — there is no
+ * creator field anywhere on this type, because there is none on the table it
+ * comes from (migration 20260811000001): `public.location_checkoffs`
+ * collects an order, never who walked it.
+ */
+export type LocationCheckoffRow = {
+  id: string;
+  itemNames: string[];
+  completedAt: string;
+};
+
+// not exported — snake_case stops at this file, same convention as locationItems.ts
+type LocationCheckoffRecord = {
+  id: string;
+  item_names: string[];
+  completed_at: string;
+};
+
+/**
+ * Every completed shop recorded for one location, in no particular order —
+ * callers (`computeRouteOrder`) fold this list into per-name and per-section
+ * averages rather than reading it in sequence, so there is nothing an
+ * ordering would buy.
+ */
+export async function loadLocationCheckoffs(
+  client: SupabaseClient,
+  locationId: string,
+): Promise<Outcome<LocationCheckoffRow[]>> {
+  const { data, error } = await client
+    .from('location_checkoffs')
+    .select('id, item_names, completed_at')
+    .eq('location_id', locationId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as LocationCheckoffRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      itemNames: row.item_names,
+      completedAt: row.completed_at,
+    })),
+  };
+}
+
+/**
+ * Records one completed shop at a location: the item names checked off,
+ * normalized, in the order `orderedCheckedItemNames` determined.
+ *
+ * Normalizes every entry itself via `normalizeItemName`, matching
+ * `tagItemLocation`'s convention of normalizing internally rather than
+ * trusting the caller to have done it. Unlike `tagItemLocation`, no error
+ * code is special-cased — there is no unique constraint on this table, no
+ * race to swallow (see migration 20260811000001's header), so every error
+ * surfaces via `humanise()` normally.
+ */
+export async function recordLocationCheckoff(
+  client: SupabaseClient,
+  locationId: string,
+  itemNames: readonly string[],
+): Promise<Outcome<void>> {
+  const { error } = await client.from('location_checkoffs').insert({
+    location_id: locationId,
+    item_names: itemNames.map(normalizeItemName),
+  });
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * The names of a list's checked items, in the order they were actually
+ * checked off during a shop.
+ *
+ * `checked_at` is the only signal this app has for "when was this checked,"
+ * so ascending `checked_at` is the one coherent reading of "the order
+ * actually checked during that shop." Ties break on `id`, mirroring
+ * `loadItems()`'s own `.order('position').order('id')` tie-break convention
+ * in `mobile/src/lib/lists.ts`: two items checked at the same stored
+ * timestamp need a deterministic order, and `id` is the one field guaranteed
+ * to differ between them and to sort identically on every device.
+ */
+export function orderedCheckedItemNames<
+  T extends { id: string; name: string; checkedAt: string | null },
+>(items: readonly T[]): string[] {
+  return items
+    .filter((item): item is T & { checkedAt: string } => item.checkedAt !== null)
+    .slice()
+    .sort((a, b) => {
+      const byCheckedAt = new Date(a.checkedAt).getTime() - new Date(b.checkedAt).getTime();
+      return byCheckedAt !== 0 ? byCheckedAt : a.id.localeCompare(b.id);
+    })
+    .map((item) => item.name);
+}
+
+/** Arithmetic mean of a non-empty array of numbers. */
+function mean(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+/**
+ * Orders a list's items for Shopping Mode using a location's accumulated
+ * check-off history and item-location tags. Design source: 03-SPEC.md §
+ * Slice 7's Agreed block.
+ *
+ * Three-tier fallback, resolved once per item into a single sort key:
+ *
+ * 1. An item with its own prior check-off history at this location sorts by
+ *    its mean historical position, averaged across every `location_checkoffs`
+ *    row whose array contains it.
+ * 2. An item with no check-off history of its own but a known
+ *    `location_items` tag falls back to that section's mean position — the
+ *    mean position, across the same history, of every *other* item sharing
+ *    that section text.
+ * 3. An item with neither signal — including every item at a location with
+ *    zero history — keeps its original entry order, appended after every
+ *    item that resolved a position. This is why zero-history locations
+ *    produce entry order for free.
+ *
+ * One map-building pass, no rescans.
+ */
+export function computeRouteOrder<T extends { name: string }>(
+  items: readonly T[],
+  locationItems: readonly LocationItemRow[],
+  checkoffs: readonly LocationCheckoffRow[],
+): T[] {
+  // 1. Every position a name has ever been checked at, across every shop.
+  const positionsByName = new Map<string, number[]>();
+  for (const checkoff of checkoffs) {
+    checkoff.itemNames.forEach((name, index) => {
+      const positions = positionsByName.get(name);
+      if (positions) {
+        positions.push(index);
+      } else {
+        positionsByName.set(name, [index]);
+      }
+    });
+  }
+
+  // 2. Each name's own mean position, from its own history alone.
+  const ownMeanByName = new Map<string, number>();
+  for (const [name, positions] of positionsByName) {
+    ownMeanByName.set(name, mean(positions));
+  }
+
+  // 3. The section each name is tagged with, if any.
+  const sectionByName = new Map<string, string>();
+  for (const tag of locationItems) {
+    sectionByName.set(tag.name, tag.section);
+  }
+
+  // 4. Every position recorded for names sharing a section, pooled together.
+  // An item with its own direct history still pools into its section's
+  // numbers for *other* items' fallback — this is intentional. An item that
+  // itself falls back, by construction, has no entry in positionsByName, so
+  // it can never pollute its own fallback average.
+  const sectionPositions = new Map<string, number[]>();
+  for (const [name, positions] of positionsByName) {
+    const section = sectionByName.get(name);
+    if (section === undefined) {
+      continue;
+    }
+    const pooled = sectionPositions.get(section);
+    if (pooled) {
+      pooled.push(...positions);
+    } else {
+      sectionPositions.set(section, [...positions]);
+    }
+  }
+
+  // 5. Each section's mean position, from the pooled history above.
+  const sectionMeanBySection = new Map<string, number>();
+  for (const [section, positions] of sectionPositions) {
+    sectionMeanBySection.set(section, mean(positions));
+  }
+
+  // 6. One sort key per item, in original order.
+  const keyed = items.map((item) => {
+    const name = normalizeItemName(item.name);
+    const ownMean = ownMeanByName.get(name);
+    if (ownMean !== undefined) {
+      return { item, key: ownMean };
+    }
+    const section = sectionByName.get(name);
+    const sectionMean = section !== undefined ? sectionMeanBySection.get(section) : undefined;
+    if (sectionMean !== undefined) {
+      return { item, key: sectionMean };
+    }
+    return { item, key: Number.POSITIVE_INFINITY };
+  });
+
+  // 7. Stable sort ascending by key — Array.prototype.sort is spec-stable
+  // since ES2019, so ties (including every unresolved item, all tied at
+  // +Infinity) keep original relative/entry order for free.
+  return keyed.sort((a, b) => a.key - b.key).map((entry) => entry.item);
+}

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   Body,
   CheckTarget,
+  Confirm,
   EmptyState,
   ErrorNote,
   Field,
@@ -18,7 +19,13 @@ import {
 } from '../components/ui';
 import { useListItems } from '../hooks/useListItems';
 import type { ListsView } from '../hooks/useLists';
+import { useLocationCheckoffs } from '../hooks/useLocationCheckoffs';
 import { useLocationItems } from '../hooks/useLocationItems';
+import {
+  computeRouteOrder,
+  orderedCheckedItemNames,
+  recordLocationCheckoff,
+} from '../lib/locationCheckoffs';
 import { sectionForItemName, tagItemLocation } from '../lib/locationItems';
 import { setChecked, type ListItemRow } from '../lib/lists';
 import type { RootStackParamList } from '../navigation/types';
@@ -57,9 +64,9 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * back whatever `checked_at` is currently stored. There is no `shop_sessions` row
  * to resume and nothing here to reconstruct.
  *
- * No reordering, grouping, or "Finish shopping" button — out of scope per Slice 5's
- * plan: items render in whatever order `useListItems` returns, unchanged, and there
- * is no session row to finalize.
+ * No grouping of checked items — out of scope per Slice 5's plan, still: checked
+ * items stay in place rather than sinking to the bottom, and there is no session
+ * row to finalize beyond the one Slice 7 adds below.
  *
  * Slice 6 adds crowdsourced section tagging alongside check-off, one control per
  * item beneath its `CheckTarget` row rather than folded into it — `CheckTarget`'s
@@ -69,6 +76,16 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * inline composer for this row only (`composingItemId`) rather than a modal or a
  * second screen, matching the low-friction, walking-through-the-store spirit the
  * rest of this screen already has.
+ *
+ * Slice 7 adds both reordering and a "Finish shopping" button. Items render via
+ * `computeRouteOrder` (`../lib/locationCheckoffs`) rather than in whatever order
+ * `useListItems` returns — a read-time sort only, `position` is never written
+ * (03-SPEC.md § Slice 7's Agreed block). "Finish shopping" is confirm-gated like
+ * this screen's siblings' occasional destructive/one-way actions and records one
+ * `location_checkoffs` row via `recordLocationCheckoff`, snapshotting whatever's
+ * checked, in check-off order, the moment it's pressed — it does not uncheck
+ * anything or touch list reuse across weeks, matching this project's habit of not
+ * building ahead of the slice (9) that actually needs that.
  */
 export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   const tokens = useTheme();
@@ -89,10 +106,18 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     list?.locationId ?? null,
   );
 
+  const { view: checkoffs, refresh: refreshCheckoffs } = useLocationCheckoffs(
+    client,
+    list?.locationId ?? null,
+  );
+
   const [pending, setPending] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [composingItemId, setComposingItemId] = useState<string | null>(null);
   const [sectionDraft, setSectionDraft] = useState('');
+  const [confirmingFinish, setConfirmingFinish] = useState(false);
+  const [finishingShopping, setFinishingShopping] = useState(false);
+  const [justFinished, setJustFinished] = useState(false);
 
   useLayoutEffect(() => {
     // Same reasoning as ListDetailScreen's header: it carries the list's name, and
@@ -106,6 +131,7 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     if (pending.has(item.id)) {
       return;
     }
+    setJustFinished(false);
 
     setPending((current) => new Set(current).add(item.id));
     setError(null);
@@ -174,6 +200,36 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     }
   }
 
+  async function finishShopping(items: ListItemRow[]) {
+    if (!list || list.locationId === null) {
+      return;
+    }
+    if (items.filter((item) => item.checkedAt !== null).length === 0) {
+      return;
+    }
+    if (finishingShopping || pending.size > 0) {
+      return;
+    }
+    setFinishingShopping(true);
+    setError(null);
+    try {
+      const outcome = await recordLocationCheckoff(
+        client,
+        list.locationId,
+        orderedCheckedItemNames(items),
+      );
+      if (!outcome.ok) {
+        setError(outcome.message);
+        return;
+      }
+      await refreshCheckoffs();
+      setConfirmingFinish(false);
+      setJustFinished(true);
+    } finally {
+      setFinishingShopping(false);
+    }
+  }
+
   if (lists.status === 'loading') {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
@@ -217,9 +273,14 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   }
 
   // Past this point `list.locationId` is known non-null, so `useLocationItems`
-  // above was called with a real id rather than null — these two gates are safe
-  // to merge with (loading) and mirror (error) the existing view.status ones.
-  if (view.status === 'loading' || locationItems.status === 'loading') {
+  // and `useLocationCheckoffs` above were both called with a real id rather
+  // than null — these gates are safe to merge with (loading) and mirror
+  // (error) the existing view.status ones.
+  if (
+    view.status === 'loading' ||
+    locationItems.status === 'loading' ||
+    checkoffs.status === 'loading'
+  ) {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
         <ActivityIndicator color={tokens.color.accent} size="large" />
@@ -243,6 +304,14 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     );
   }
 
+  if (checkoffs.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={checkoffs.message} />
+      </Screen>
+    );
+  }
+
   if (view.items.length === 0) {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
@@ -257,6 +326,7 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   }
 
   const items = view.items;
+  const orderedItems = computeRouteOrder(items, locationItems.items, checkoffs.checkoffs);
   const checkedCount = items.filter((item) => item.checkedAt !== null).length;
 
   return (
@@ -265,7 +335,7 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
 
       {error ? <ErrorNote message={error} /> : null}
 
-      {items.map((item) => {
+      {orderedItems.map((item) => {
         const section = sectionForItemName(locationItems.items, item.name);
         const composing = composingItemId === item.id;
 
@@ -320,6 +390,29 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
           </View>
         );
       })}
+
+      {justFinished ? (
+        <Body>Shop recorded — this location's ordering will reflect it next time.</Body>
+      ) : null}
+
+      {confirmingFinish ? (
+        <Confirm
+          message="This records everything currently checked, in the order you checked it, as one completed shop at this location. It won't uncheck anything or change today's list."
+          confirmLabel="Finish shopping"
+          onConfirm={() => void finishShopping(items)}
+          onCancel={() => setConfirmingFinish(false)}
+          busy={finishingShopping}
+        />
+      ) : (
+        <SecondaryButton
+          label="Finish shopping"
+          onPress={() => {
+            setError(null);
+            setConfirmingFinish(true);
+          }}
+          disabled={checkedCount === 0 || pending.size > 0}
+        />
+      )}
     </Screen>
   );
 }

--- a/supabase/migrations/20260811000001_location_checkoffs.sql
+++ b/supabase/migrations/20260811000001_location_checkoffs.sql
@@ -1,0 +1,117 @@
+-- Slice 7 — Route Learning & Auto-Ordering.
+--
+-- `public.location_checkoffs` is global and anonymous, exactly like
+-- `public.location_items` (migration 20260811000000) and `public.locations`
+-- (migration 20260810000005), and for the same reason: 03-SPEC.md § 0 treats
+-- location data and household data as two classes that must never share an
+-- access-control path. There is no household_id, no list_id, no owner_id, and
+-- no creator column of any kind — a completed shop's checked-item order is a
+-- fact about the *location*, never about who shopped it. This is the role
+-- 03-SPEC.md § 1's aspirational `shop_sessions` sketch originally described,
+-- deliberately split off it: a household-attributed shop-history table mixing
+-- both classes is Slice 9's own `shop_sessions`, built there, whenever that
+-- slice actually needs it — not built ahead of it here.
+--
+-- `item_names` is an ordered array, not a join table, because the array's own
+-- element order IS the datum `computeRouteOrder`
+-- (mobile/src/lib/locationCheckoffs.ts) reads — a join table would need its
+-- own position column to recover an order Postgres arrays already carry for
+-- free, for a table with no other reason to exist.
+--
+-- `on delete cascade` on `location_id` (NOT `lists.location_id`'s `on delete
+-- set null`, migration 20260810000006) — matches `location_items.location_id`
+-- (migration 20260811000000)'s own cascade, not `locations.created_by`'s
+-- set-null. A checkoff row, like a tag, is meaningless once its location is
+-- gone: its array only makes sense relative to *that* location's other shops,
+-- so orphaning it would leave dead data nothing ever reads again.
+--
+-- No `unique` constraint, unlike `location_items`' `unique (location_id,
+-- name)`. That constraint arbitrates a race for a single mutable fact — "what
+-- section is this item in right now" — where two concurrent writers must not
+-- both win. A checkoff row has no shared-key to race over: every completed
+-- shop is its own independent historical fact, two shoppers finishing at the
+-- same location around the same moment simply produce two rows, and neither
+-- write ever reads shared state before writing. A bare, unconditional INSERT
+-- is correct under arbitrary concurrency here.
+--
+-- No `deleted_at`, no update policy, no delete policy or grant — stronger
+-- than `location_items`' "not built yet" stance (that table's own header
+-- notes Slice 8 will add an UPDATE path for corrections). A checkoff row is
+-- an immutable record of one completed shop; nothing in this slice or any
+-- slice planned so far ever corrects or removes one after the fact.
+--
+-- No new row in `supabase_realtime`'s publication membership, matching
+-- `location_items` and `locations` (only `lists`/`list_items` were ever
+-- added, in migration 20260810000004). `ShoppingScreen` computes route order
+-- from a fresh load via `useLocationCheckoffs`, load-on-mount, no
+-- subscription — the acceptance test (03-SPEC.md § Slice 7 / issue #7) is
+-- satisfied by a location accumulating history across separate completed
+-- shops, never by a live push mid-shop.
+--
+-- No RPC for the write itself, same reasoning as 20260811000000's header:
+-- "may I write this" is exactly "are you authenticated," a plain `with
+-- check`, and there is no atomicity/authorization invariant beyond it. The
+-- one function this migration adds (`item_names_are_normalized`, below)
+-- exists only because Postgres forbids a subquery — including one only ever
+-- reading the row's own column via `unnest()` — directly inside a `check`
+-- expression; wrapping the per-element test in a function sidesteps that
+-- restriction without touching RLS.
+--
+-- `item_names` elements are constrained to already be normalized
+-- (`lower(btrim(...))`), mirroring `location_items.name`'s own check for the
+-- same reason that migration gives: this column is a lookup key
+-- `computeRouteOrder` joins against `location_items.name` and against every
+-- other checkoff row's own entries, and normalization has to be enforced
+-- once, at the schema, rather than trusted to every future insert to
+-- remember — a silently-unnormalized entry wouldn't error, it would just
+-- never match, and the item would quietly fall back to entry order forever.
+-- Per-element *length* is deliberately left unbounded here (unlike
+-- `location_items.name`'s `between 1 and 120`): every element already passed
+-- that bound once, at `list_items.name`'s own check constraint, when it was
+-- first typed in — re-bounding a value copied from an already-validated
+-- column would only be defensive against Postgres itself.
+
+create or replace function public.item_names_are_normalized(names text[])
+returns boolean
+language sql
+immutable
+set search_path = ''
+as $$
+  select not exists (
+    select 1 from unnest(names) as raw_name
+    where raw_name <> lower(btrim(raw_name))
+  );
+$$;
+
+revoke execute on function public.item_names_are_normalized(text[]) from public, anon;
+grant execute on function public.item_names_are_normalized(text[]) to authenticated;
+
+create table public.location_checkoffs (
+  id uuid primary key default gen_random_uuid(),
+  location_id uuid not null references public.locations (id) on delete cascade,
+  item_names text[] not null
+    check (cardinality(item_names) > 0)
+    check (public.item_names_are_normalized(item_names)),
+  completed_at timestamptz not null default now()
+);
+
+create index location_checkoffs_location_id_idx
+  on public.location_checkoffs (location_id);
+
+alter table public.location_checkoffs enable row level security;
+
+create policy location_checkoffs_select_all on public.location_checkoffs
+  for select to authenticated
+  using (true);
+
+create policy location_checkoffs_insert_all on public.location_checkoffs
+  for insert to authenticated
+  with check (true);
+
+-- No update, no delete policy or grant — see header: append-only by design,
+-- not merely unfinished.
+
+revoke all on table public.location_checkoffs from anon, authenticated;
+
+grant select (id, location_id, item_names, completed_at) on table public.location_checkoffs to authenticated;
+grant insert on table public.location_checkoffs to authenticated;

--- a/supabase/tests/rls_location_checkoffs.sql
+++ b/supabase/tests/rls_location_checkoffs.sql
@@ -1,0 +1,251 @@
+-- RLS/grant tests for public.location_checkoffs (Slice 7 — Route Learning &
+-- Auto-Ordering).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- WHAT IT IS REALLY GUARDING. `public.location_checkoffs` (migration
+-- 20260811000001) is deliberately global and anonymous, same class as
+-- `public.location_items`/`public.locations` per 03-SPEC.md § 0 — assertion 1 is
+-- this file's direct analogue of rls_location_items.sql's assertion 1: a stranger
+-- who shares nothing with the checkoff's author must still see it. Assertion 2
+-- checks the stronger anonymity claim structurally, at the schema level, rather
+-- than only behaviourally — there is no creator, household, or list column to
+-- withhold in the first place, not merely one that is withheld from a grant.
+-- Assertion 3 checks that writing needs no household at all, matching
+-- `location_items_insert_all`'s own "are you authenticated" bar. Assertion 4
+-- checks the foreign key does real work. Assertion 5 checks the cascade-delete
+-- behaviour this table deliberately chose over `lists.location_id`'s set-null.
+-- Assertions 6-7 check the two check constraints — non-empty array and
+-- normalization — do real enforcement work rather than being decorative.
+--
+-- Fixtures are the premise, not the thing under test, so the location rows are
+-- inserted as the owning role, which bypasses RLS. Only the assertions run as
+-- `authenticated`. `request.jwt.claims` must be set *before* the role switch:
+-- after it, the session no longer has the privilege to set the GUC on some
+-- configurations, and auth.uid() reads that GUC.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. E and F share nothing — no household, no prior relationship. One
+-- location L, created by E for convenience (created_by is not under test here).
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-0000000000e1', true),  -- E
+  ('00000000-0000-4000-8000-0000000000f1', true);  -- F
+
+insert into public.locations (id, name, lat, lng, created_by) values
+  ('80000000-0000-4000-8000-000000000001',
+   'Test Supermarket', -36.8485, 174.7633,
+   '00000000-0000-4000-8000-0000000000e1');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control, as E. Without this, the "must be visible"
+-- assertion below would prove nothing if the policy hid everything, including
+-- from the row's own author.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  insert into public.location_checkoffs (location_id, item_names)
+  values ('80000000-0000-4000-8000-000000000001', array['milk', 'bread']);
+
+  if (select count(*) from public.location_checkoffs
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and item_names = array['milk', 'bread']) <> 1 then
+    raise exception 'FAIL: E cannot see the checkoff E just inserted';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — THE core property. As F, who shares no household with E and did
+-- not write the row: E's checkoff must still be visible, with item_names intact,
+-- on a plain select scoped to location L.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select item_names from public.location_checkoffs
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and item_names = array['milk', 'bread']) <> array['milk', 'bread'] then
+    raise exception 'FAIL: F cannot see E''s checkoff, or item_names was not intact — location_checkoffs is not actually global (it is scoping visibility by author or household when it must not, or should never have had one to begin with)';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 2 — anonymity, structurally. No column on this table can name a
+-- creator, household, or list, not merely one withheld from a grant. Metadata
+-- query, no role switch needed.
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  if exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'location_checkoffs'
+      and column_name in (
+        'created_by', 'user_id', 'owner_id', 'household_id', 'list_id',
+        'tagged_by', 'author_id'
+      )
+  ) then
+    raise exception 'FAIL: public.location_checkoffs has a creator/household/list-shaped column — this table must never attribute a completed shop to anyone';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — no household required to write. As F, who has no household at
+-- all, inserting a second, independent checkoff at L must succeed and be
+-- visible.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  insert into public.location_checkoffs (location_id, item_names)
+  values ('80000000-0000-4000-8000-000000000001', array['eggs']);
+
+  if (select count(*) from public.location_checkoffs
+      where location_id = '80000000-0000-4000-8000-000000000001'
+        and item_names = array['eggs']) <> 1 then
+    raise exception 'FAIL: F (no household at all) could not record a checkoff, or cannot see the checkoff F just inserted';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 4 — the foreign key does real work.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_checkoffs (location_id, item_names)
+    values ('99999999-0000-4000-8000-000000000000', array['milk']);
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: inserting a checkoff against a nonexistent location_id succeeded — the foreign key constraint is not enforced';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 5 — cascade delete. A second location M (not L, so this doesn't
+-- disturb the other assertions' state) with its own checkoff row; deleting M
+-- as the superuser fixture role (no delete grant exists for `authenticated` on
+-- `locations`) must take the checkoff row with it.
+-- ---------------------------------------------------------------------------
+
+insert into public.locations (id, name, lat, lng, created_by) values
+  ('80000000-0000-4000-8000-000000000002',
+   'Test Superette', -36.85, 174.76,
+   '00000000-0000-4000-8000-0000000000e1');
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  insert into public.location_checkoffs (location_id, item_names)
+  values ('80000000-0000-4000-8000-000000000002', array['butter']);
+end $$;
+
+reset role;
+
+delete from public.locations where id = '80000000-0000-4000-8000-000000000002';
+
+do $$
+begin
+  if (select count(*) from public.location_checkoffs
+      where location_id = '80000000-0000-4000-8000-000000000002') <> 0 then
+    raise exception 'FAIL: deleting location M left its checkoff row behind — on delete cascade is not working';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 6 — the non-empty-array check constraint does real work.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_checkoffs (location_id, item_names)
+    values ('80000000-0000-4000-8000-000000000001', '{}'::text[]);
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: an empty item_names array was accepted — the cardinality(item_names) > 0 check constraint is not enforced';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 7 — the normalization check constraint does real work. An
+-- unnormalized element must be rejected, not silently stored or silently
+-- normalized.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e1","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_checkoffs (location_id, item_names)
+    values ('80000000-0000-4000-8000-000000000001', array['Milk']);
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: an unnormalized item name (''Milk'') was accepted — the item_names_are_normalized check constraint is not enforced';
+  end if;
+end $$;
+
+reset role;
+
+rollback;


### PR DESCRIPTION
Closes #7.

## Problem Agreement
The ordering heuristic was a genuine open question — the issue's own
`ready-for-human` label was accurate, confirmed by re-reading
`01-CRD.md`/`02-DESIGN-REFERENCE.md` and finding no resolution in either.
Per `PROTOCOL.md` Step 3's escalation trigger, three real forks were put to
the user before any Investigator/Planner/Code Writer work started:

1. A separate anonymous `location_checkoffs` table vs. building
   `03-SPEC.md § 1`'s CRD-sketched combined `shop_sessions` table now.
2. Observed-order-primary vs. section-grouped-primary vs. tags-only ordering.
3. A new "Finish shopping" button vs. auto-completing on the last item checked.

All three resolved to the recommended option. Full reasoning recorded in
`03-SPEC.md § Slice 7`'s "Agreed 2026-08-11" block.

Also reopened issue #7 this session — a previous session's handoff commit
(`93fca49`, "resolve #7 label-staleness loose end") got picked up by GitHub's
close-keyword detection and auto-closed the issue despite no build work
having happened.

## Schema
New `public.location_checkoffs` table (migration `20260811000001`): one row
per completed shop — `location_id`, an ordered array of normalized checked
item names, `completed_at`. Global and anonymous, same class as
`location_items`/`locations` per `03-SPEC.md § 0` — no `household_id`,
`list_id`, or user column of any kind. `on delete cascade` on `location_id`
(matches `location_items`, not `lists.location_id`'s set-null). Not added to
the `supabase_realtime` publication (matches `location_items`/`locations` —
the acceptance test needs a fresh load, not live mid-shop push).

## Client
- `mobile/src/lib/locationCheckoffs.ts` — `loadLocationCheckoffs`,
  `recordLocationCheckoff`, `orderedCheckedItemNames`, and the three-tier
  `computeRouteOrder`: an item sorts by its own mean historical position at
  this location if it has one; else by its section tag's mean position
  (pooled from every *other* item sharing that tag); else it keeps its
  original entry order, appended last.
- `mobile/src/hooks/useLocationCheckoffs.ts` mirrors `useLocationItems.ts`.
- `ShoppingScreen.tsx` renders `computeRouteOrder`'s output instead of the
  raw list order — read-time sort only, `position` is still never written
  (Slice 2's already-locked decision) — and gained a confirm-gated "Finish
  shopping" button that snapshots whatever's checked, in check-off order,
  into one `location_checkoffs` row. Doesn't reset `checked_at` or touch list
  reuse across weeks (Slice 9 territory, deliberately out of scope here).

## Testing checklist (from #7)
- [x] A location with zero prior data orders a new list in entry/arbitrary order
- [x] The same location after several shops with location tags present
      produces a stable, repeatable non-arbitrary order for the same item set

## Verification
- `npx tsc --noEmit` clean.
- `supabase/tests/rls_location_checkoffs.sql` — 8 assertions (positive
  control, cross-household visibility, structural anonymity,
  no-household-required-to-write, FK enforcement, cascade delete, both check
  constraints) ran clean against the live project.
- Both acceptance-test bullets live-verified against a local dev session
  (`npx expo start --web`) rather than production — production and every
  Vercel preview share the same live Supabase project, and production now
  holds a real household's data, so test writes went through local dev
  instead:
  - Fresh location, fresh list (Bread, Milk, Eggs, Apples) → Shopping Mode
    rendered exact entry order.
  - Two recorded shops at that location (checked eggs→bread→milk→apples both
    times, tagged milk "Dairy Aisle 3") → a *new* list with a *different*
    entry order (apples→milk→bread→eggs) rendered back in the observed
    eggs→bread→milk→apples order, reproduced identically after a full cold
    reload.
  - Isolated and confirmed the section-tag fallback tier specifically: an
    untagged, unchecked item ("yogurt") sorted last (zero-signal tier); once
    tagged with milk's own section, it moved to slot in right at milk's mean
    position, tie-broken by entry order — matching the algorithm's
    hand-computed prediction exactly.
- All test data (1 location, 2 lists, 2 checkoff rows, 2 location_items tags,
  1 anonymous user) queried and confirmed as this session's own before
  deletion, then deleted and reverified at zero.
- `mobile/app.json` and `mobile/package.json` bumped to `0.0.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)