### PR TITLE
Slice 8: Location Correction Voting

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,6 +5,100 @@
 
 ## Last active
 
+- **Slice 8 — Location Correction Voting is implemented and verified, PR open,
+  not yet merged.** [PR #20](https://github.com/mp3anthony/cartel/pull/20),
+  branch `slice-8-location-correction-voting`, closes issue #8 on merge.
+  Waiting on the user's explicit go-ahead to merge before this becomes done —
+  don't merge it automatically at the start of next session; ask first, the
+  same gate Slice 6/7/the version-footer task all went through.
+  - **Label rationale re-checked, same as #7's staleness check, and this time
+    it held.** `01-CRD.md § 8` explicitly resolves quorum-of-2 as the
+    mechanism and `03-SPEC.md § Slice 8` gives the same scope text as the
+    issue — no genuine open question, so no Problem Agreement round; went
+    straight to Investigator → Planner → Code Writer.
+  - **The central design fork was RPC-vs-direct-table-write, and this is the
+    first table in the schema where the RPC side actually won.** Every prior
+    table (`location_items`, `location_checkoffs`, `locations`) concluded no
+    function was needed because "may I write this row" reduced to a plain RLS
+    check. Slice 8's write is different in kind: applying a correction on
+    quorum is an atomic check-then-write that spans *two* tables
+    (`location_item_votes` and `location_items.section`), which `using`/`with
+    check` has no way to express. `public.vote_location_item_correction()`
+    (`security definer`) is the sole write path for both tables — neither has
+    an INSERT/UPDATE policy or grant reachable by a client at all, a
+    deliberately *stronger* stance than `location_items`' own migration
+    header predicted for itself ("Slice 8 will add an UPDATE policy") — that
+    prediction was wrong once the atomicity requirement was actually worked
+    through; overridden, not followed.
+  - **`location_item_votes.voter_id` is stored but withheld from every SELECT
+    grant, matching `locations.created_by`'s precedent, not
+    `location_items`' complete absence of a creator column.** Real functional
+    reason this table has that `location_items`/`location_checkoffs` never
+    did: telling a proposer apart from an *independent* second confirmer
+    needs some durable per-vote identity across two separate calls. Never
+    reachable by any client query — the one place it's read is inside the
+    function body.
+  - **One table serves both "propose" and "confirm"** — no separate
+    corrections table. A "proposed correction" is the distinct-values grouping
+    of `(location_id, item_name, proposed_section)` that emerges from
+    whichever vote rows exist; the first vote for a not-yet-seen tuple *is*
+    the proposal, a second independent vote *is* the confirmation. Same
+    voter voting the same tuple twice collides with `unique(location_id,
+    item_name, proposed_section, voter_id)` and is rejected (`already_voted`)
+    rather than silently accepted — deliberately the opposite of
+    `tagItemLocation`'s 23505-is-fine leniency, because a duplicate vote from
+    the same user is not equivalent to genuine second-voter progress. Two
+    different proposed corrections for the same item can be pending at once;
+    applying one via quorum deletes *all* pending votes for that item, not
+    just the winning tuple's own two.
+  - **`mobile/src/lib/locationItemVotes.ts` / `useLocationItemVotes.ts`**
+    mirror `locationItems.ts`/`useLocationItems.ts` field-for-field.
+    `ShoppingScreen.tsx`'s tagged-item `Badge` gained a sibling pencil
+    `IconButton` opening a second inline composer
+    (`correctingItemId`, same one-row-at-a-time shape as `composingItemId`);
+    pending corrections render as a plain `Body` line + single-tap
+    `PrimaryButton` "Confirm" — deliberately *not* the `Confirm` in-place-card
+    primitive, because this system has no reject/veto verb (a user who
+    disagrees with a proposal just never taps it) and `Confirm`'s contract
+    requires an `onCancel` that would invent meaning nothing here has. Every
+    viewer sees the same "Confirm" affordance regardless of whether they
+    proposed it — the app never learns who voted, so there's no client-side
+    attempt to hide it from the proposer; their own re-tap is rejected
+    server-side and surfaces through the same `ErrorNote` path every other
+    rejected write already uses.
+  - **`supabase/tests/rls_location_item_votes.sql`, 14 assertions, run clean
+    against the live project — independently re-run by the orchestrator, not
+    just trusted from the implementing agent's own report.** Covers: quorum
+    application + vote-row cleanup (assertions 0-1), `already_voted`
+    rejection (2-3), two independent pending corrections coexisting and one
+    applying wiping both (4-5), `correction_matches_current` /
+    `item_not_tagged` rejection (6-7), no-household-required (8), `voter_id`
+    unreadability (9), no direct-INSERT bypass of the RPC (10), composite FK
+    enforcement + cascade (11-12), both check constraints (13).
+  - **Both acceptance-test bullets live-verified against local dev with two
+    genuinely distinct anonymous users** (Browser pane + Claude-in-Chrome,
+    confirmed differing `auth.uid()`s before trusting anything, per the
+    standing trap below). User A tagged a fresh item "Aisle 3", proposed
+    "Aisle 9" — badge stayed "Aisle 3" (issue's first bullet) — then A's own
+    tap on "Confirm" for their own proposal was rejected with the
+    `already_voted` prose, badge still "Aisle 3" (the explicit
+    single-user-edits-stay-pending negative case, not just implied). User B
+    (different list, no shared household, matched via lowercase "milk"
+    proving the name-normalization join) saw the same pending correction and
+    confirmed it independently — both sessions read "Aisle 9" after reload,
+    confirmed directly against the database (`location_items.section =
+    'Aisle 9'`, zero remaining `location_item_votes` rows for that item). All
+    test rows (2 anon users, 2 lists, 1 location, 1 location_items row)
+    queried and confirmed as this session's own before deletion, then deleted
+    and reverified at zero.
+  - `npx tsc --noEmit` clean. `mobile/app.json` and `mobile/package.json`
+    bumped to `0.0.8`.
+  - **Next up: Slice 9 — Shop History & List Templates, issue #9** (depends
+    on Slice 5, already merged — no blocker), the only remaining
+    `ready-for-agent` slice. It's the slice that finally needs a real,
+    household-attributed `shop_sessions` table — start by re-reading Slice
+    7's entry below on why `location_checkoffs` was deliberately built
+    anonymous/global instead and structurally can't be reused for it.
 - **Slice 7 — Route Learning & Auto-Ordering is done and merged.**
   [PR #19](https://github.com/mp3anthony/cartel/pull/19) merged to `main`
   (user gave the explicit go-ahead this session), closing issue #7. Feature
@@ -105,15 +199,6 @@
   same as before. Merged directly this session (user confirmed the
   go-ahead) rather than left for later, specifically so the live-environment
   verification above could happen rather than being deferred again.
-- **Next up: Slice 8 — Location Correction Voting, issue #8** (depends on
-  Slice 6, already merged — no blocker) or Slice 9 — Shop History & List
-  Templates, issue #9 (depends on Slice 5, already merged). Both are
-  labelled `ready-for-agent`; neither has had Investigator/Planner work done.
-  Slice 9 is the slice that finally needs a real, household-attributed
-  `shop_sessions` table (see this session's Slice 7 entry above for why that
-  was deliberately *not* built there) — start Slice 9 by re-reading that
-  reasoning rather than assuming the new `location_checkoffs` table is reusable
-  for it; it structurally can't be (no household/list attribution by design).
 - Full Investigator→Planner→Code Writer cycle run via subagents this session
   (no Problem Agreement round — issue was ready-for-agent and no genuinely
   open question came up). New `public.location_items` table (migration

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/hooks/useLocationItemVotes.ts
+++ b/mobile/src/hooks/useLocationItemVotes.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { loadLocationItemVotes, type LocationItemVoteRow } from '../lib/locationItemVotes';
+
+export type LocationItemVotesView =
+  | { status: 'loading' }
+  | { status: 'loaded'; votes: LocationItemVoteRow[] }
+  | { status: 'error'; message: string };
+
+/**
+ * The pending-correction vote rows recorded for one location, load-on-mount.
+ *
+ * No `postgres_changes` subscription — same reasoning as `useLocationItems` and
+ * `useLocationCheckoffs`: `public.location_item_votes` was never added to the
+ * `supabase_realtime` publication (migration 20260811000002), and this slice's
+ * acceptance test reads as satisfied by a fresh `ShoppingScreen` load, not a
+ * live push mid-shop. `refresh()` is how a caller picks up a vote it just cast,
+ * or a correction that just got applied, same as its siblings.
+ *
+ * `locationId` is nullable for the identical reason `useLocationItems`'s is:
+ * `ShoppingScreen` passes `list?.locationId ?? null` unconditionally, before
+ * `list` itself may have resolved.
+ */
+export function useLocationItemVotes(client: SupabaseClient, locationId: string | null) {
+  const [view, setView] = useState<LocationItemVotesView>({ status: 'loading' });
+  const active = useRef(true);
+
+  useEffect(() => {
+    active.current = true;
+    return () => {
+      active.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (locationId === null) {
+      return;
+    }
+    const outcome = await loadLocationItemVotes(client, locationId);
+    if (!active.current) {
+      return;
+    }
+    setView(
+      outcome.ok
+        ? { status: 'loaded', votes: outcome.value }
+        : { status: 'error', message: outcome.message },
+    );
+  }, [client, locationId]);
+
+  useEffect(() => {
+    if (locationId === null) {
+      setView({ status: 'loading' });
+      return;
+    }
+    setView({ status: 'loading' });
+    refresh();
+  }, [locationId, refresh]);
+
+  return { view, refresh };
+}

--- a/mobile/src/lib/household.ts
+++ b/mobile/src/lib/household.ts
@@ -36,6 +36,9 @@ const MESSAGES: Record<string, string> = {
   list_not_found: 'That list no longer exists.',
   not_list_owner: 'Only the person who made a list can share it.',
   already_shared: 'That list is already shared with your household.',
+  item_not_tagged: 'This item has to be tagged with a location before it can be corrected.',
+  correction_matches_current: "That's already this item's location — nothing to correct.",
+  already_voted: 'You already proposed or confirmed this correction. It needs a different person to confirm it.',
 };
 
 /**

--- a/mobile/src/lib/locationItemVotes.ts
+++ b/mobile/src/lib/locationItemVotes.ts
@@ -1,0 +1,156 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { humanise, type Outcome } from './household';
+import { normalizeItemName } from './locationItems';
+
+/**
+ * One supporting vote for a proposed correction to an item's location. There is
+ * no `voter_id` on this type, and none reaches the client at all — this table
+ * stores voter identity (migration 20260811000002's header explains why:
+ * distinguishing an independent second confirmer requires it) but withholds it
+ * from every SELECT grant, mirroring `locations.created_by` rather than
+ * `location_items`' complete absence of a creator column. `locationId` is
+ * likewise absent, matching `LocationItemRow`'s own precedent: every caller of
+ * `loadLocationItemVotes` already scopes the query to one location.
+ */
+export type LocationItemVoteRow = {
+  id: string;
+  itemName: string;
+  proposedSection: string;
+  createdAt: string;
+};
+
+/** The database's spelling of the row above, kept separate so snake_case stops here. */
+type LocationItemVoteRecord = {
+  id: string;
+  item_name: string;
+  proposed_section: string;
+  created_at: string;
+};
+
+/**
+ * A distinct pending correction for one item: a proposed new section and how
+ * many independent votes it currently has (always 1 in practice — the moment a
+ * second, independent voter lands, `vote_location_item_correction` applies the
+ * correction and deletes the vote rows in the same transaction, so a client can
+ * essentially never observe 2). Kept as a real field rather than hard-coded to
+ * 1 for correctness under the narrow, documented race
+ * `vote_location_item_correction`'s own header accepts.
+ */
+export type PendingCorrection = {
+  proposedSection: string;
+  voteCount: number;
+};
+
+/**
+ * All pending-correction vote rows recorded for one location, in no particular
+ * order — same shape and same reasoning as `loadLocationItems`: callers group
+ * this per item via `pendingCorrectionsForItemName` rather than reading it in
+ * sequence.
+ */
+export async function loadLocationItemVotes(
+  client: SupabaseClient,
+  locationId: string,
+): Promise<Outcome<LocationItemVoteRow[]>> {
+  const { data, error } = await client
+    .from('location_item_votes')
+    .select('id, item_name, proposed_section, created_at')
+    .eq('location_id', locationId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as LocationItemVoteRecord[];
+
+  return {
+    ok: true,
+    value: rows.map((row) => ({
+      id: row.id,
+      itemName: row.item_name,
+      proposedSection: row.proposed_section,
+      createdAt: row.created_at,
+    })),
+  };
+}
+
+/**
+ * Groups one item's vote rows into its distinct pending corrections, earliest
+ * first. A linear scan, not a `Map` held across renders — same reasoning as
+ * `sectionForItemName`: callers hold this per-screen, per-render, and a
+ * location's pending-vote count is tens of rows at most.
+ *
+ * `currentSection` filters out any group whose proposed value already equals
+ * the item's current section. In ordinary use this never matches anything (a
+ * proposal identical to the current value is rejected server-side before it can
+ * ever become a row — see `correction_matches_current` in
+ * `vote_location_item_correction`'s header). It exists specifically to hide the
+ * one documented, accepted race in that same header: an orphaned single vote
+ * row that briefly proposes what is, by the time anyone reads it, already the
+ * current value. Filtering it here means that harmless race is never visible in
+ * the UI at all, not merely harmless in the database.
+ */
+export function pendingCorrectionsForItemName(
+  votes: readonly LocationItemVoteRow[],
+  itemName: string,
+  currentSection: string,
+): PendingCorrection[] {
+  const key = normalizeItemName(itemName);
+  const groups = new Map<string, { voteCount: number; earliestCreatedAt: string }>();
+
+  for (const vote of votes) {
+    if (vote.itemName !== key || vote.proposedSection === currentSection) {
+      continue;
+    }
+    const existing = groups.get(vote.proposedSection);
+    if (existing) {
+      existing.voteCount += 1;
+      if (vote.createdAt < existing.earliestCreatedAt) {
+        existing.earliestCreatedAt = vote.createdAt;
+      }
+    } else {
+      groups.set(vote.proposedSection, { voteCount: 1, earliestCreatedAt: vote.createdAt });
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort((a, b) => a[1].earliestCreatedAt.localeCompare(b[1].earliestCreatedAt))
+    .map(([proposedSection, { voteCount }]) => ({ proposedSection, voteCount }));
+}
+
+/**
+ * Casts one vote for a proposed correction to an item's location — the same
+ * call whether this is the first vote for a tuple (a "propose") or a second,
+ * independent one (a "confirm"); the server has no separate code path for
+ * either (migration 20260811000002's header). Routes through the
+ * `security definer` RPC `vote_location_item_correction`, never a direct table
+ * write — this table has no INSERT grant for `authenticated` at all, and
+ * `location_items.section` has no UPDATE grant either; the function is the only
+ * way either row changes.
+ *
+ * Unlike `tagItemLocation`'s lenient treatment of a losing race, every error
+ * here — including a rejected re-vote by the same user (`already_voted`), a
+ * proposal identical to the current value (`correction_matches_current`), or a
+ * correction proposed against an untagged item (`item_not_tagged`) — is
+ * surfaced to the caller via `humanise()`, not swallowed. None of these are
+ * benign races the caller's own refresh already resolves; each means nothing
+ * happened toward the correction the caller intended.
+ */
+export async function voteLocationItemCorrection(
+  client: SupabaseClient,
+  locationId: string,
+  itemName: string,
+  proposedSection: string,
+): Promise<Outcome<void>> {
+  const { error } = await client.rpc('vote_location_item_correction', {
+    p_location_id: locationId,
+    p_item_name: itemName,
+    p_proposed_section: proposedSection,
+  });
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -21,12 +21,14 @@ import { useListItems } from '../hooks/useListItems';
 import type { ListsView } from '../hooks/useLists';
 import { useLocationCheckoffs } from '../hooks/useLocationCheckoffs';
 import { useLocationItems } from '../hooks/useLocationItems';
+import { useLocationItemVotes } from '../hooks/useLocationItemVotes';
 import {
   computeRouteOrder,
   orderedCheckedItemNames,
   recordLocationCheckoff,
 } from '../lib/locationCheckoffs';
 import { sectionForItemName, tagItemLocation } from '../lib/locationItems';
+import { pendingCorrectionsForItemName, voteLocationItemCorrection } from '../lib/locationItemVotes';
 import { setChecked, type ListItemRow } from '../lib/lists';
 import type { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../theme/ThemeProvider';
@@ -86,6 +88,28 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * checked, in check-off order, the moment it's pressed — it does not uncheck
  * anything or touch list reuse across weeks, matching this project's habit of not
  * building ahead of the slice (9) that actually needs that.
+ *
+ * Slice 8 adds correction voting on top of an already-tagged item. A tagged
+ * item's `Badge` gains a sibling pencil `IconButton` that opens a second inline
+ * composer (`correctingItemId`, the same one-row-at-a-time shape
+ * `composingItemId` already established) for proposing a new section. Any
+ * pending corrections for that item — one row per distinct proposed value,
+ * computed client-side from `useLocationItemVotes` via
+ * `pendingCorrectionsForItemName` — render beneath the tag row as a plain
+ * `Body` line plus a single-tap `PrimaryButton` labelled "Confirm", not gated
+ * behind the `Confirm` in-place-card primitive: there is no reject/veto verb in
+ * this system (a user who disagrees with a proposed correction simply never
+ * taps it), so borrowing a component whose contract requires an `onCancel`
+ * would invent meaning nothing here actually has. Every viewer sees the same
+ * "Confirm" affordance regardless of whether they proposed the correction
+ * themselves — the app never learns or shows who voted (migration
+ * 20260811000002), so it makes no client-side attempt to hide the button from a
+ * proposer; a proposer's own re-tap is rejected server-side (`already_voted`)
+ * and surfaces through the same `error`/`ErrorNote` path every other rejected
+ * write in this screen already uses. Both the propose-submit and the
+ * confirm-tap reuse the same shared `pending` Set this screen's other two
+ * writes already use, for the same reason Slice 6 gave: each is "this item's
+ * row has a write in flight."
  */
 export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   const tokens = useTheme();
@@ -111,10 +135,17 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     list?.locationId ?? null,
   );
 
+  const { view: itemVotes, refresh: refreshLocationItemVotes } = useLocationItemVotes(
+    client,
+    list?.locationId ?? null,
+  );
+
   const [pending, setPending] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [composingItemId, setComposingItemId] = useState<string | null>(null);
   const [sectionDraft, setSectionDraft] = useState('');
+  const [correctingItemId, setCorrectingItemId] = useState<string | null>(null);
+  const [correctionDraft, setCorrectionDraft] = useState('');
   const [confirmingFinish, setConfirmingFinish] = useState(false);
   const [finishingShopping, setFinishingShopping] = useState(false);
   const [justFinished, setJustFinished] = useState(false);
@@ -191,6 +222,88 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
 
       await refreshLocationItems();
       cancelTagging();
+    } finally {
+      setPending((current) => {
+        const next = new Set(current);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  }
+
+  function beginCorrecting(itemId: string) {
+    setError(null);
+    setCorrectingItemId(itemId);
+    setCorrectionDraft('');
+  }
+
+  function cancelCorrecting() {
+    setCorrectingItemId(null);
+    setCorrectionDraft('');
+  }
+
+  async function submitCorrection(item: ListItemRow) {
+    if (!list || list.locationId === null) {
+      return;
+    }
+    if (correctionDraft.trim().length === 0 || pending.has(item.id)) {
+      return;
+    }
+
+    setPending((current) => new Set(current).add(item.id));
+    setError(null);
+
+    try {
+      const outcome = await voteLocationItemCorrection(
+        client,
+        list.locationId,
+        item.name,
+        correctionDraft,
+      );
+
+      if (!outcome.ok) {
+        setError(outcome.message);
+        return;
+      }
+
+      await refreshLocationItems();
+      await refreshLocationItemVotes();
+      cancelCorrecting();
+    } finally {
+      setPending((current) => {
+        const next = new Set(current);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  }
+
+  async function confirmCorrection(item: ListItemRow, proposedSection: string) {
+    if (!list || list.locationId === null) {
+      return;
+    }
+    if (pending.has(item.id)) {
+      return;
+    }
+
+    setPending((current) => new Set(current).add(item.id));
+    setError(null);
+
+    try {
+      const outcome = await voteLocationItemCorrection(
+        client,
+        list.locationId,
+        item.name,
+        proposedSection,
+      );
+
+      if (!outcome.ok) {
+        setError(outcome.message);
+        return;
+      }
+
+      await refreshLocationItems();
+      await refreshLocationItemVotes();
     } finally {
       setPending((current) => {
         const next = new Set(current);
@@ -279,7 +392,8 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   if (
     view.status === 'loading' ||
     locationItems.status === 'loading' ||
-    checkoffs.status === 'loading'
+    checkoffs.status === 'loading' ||
+    itemVotes.status === 'loading'
   ) {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
@@ -312,6 +426,14 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     );
   }
 
+  if (itemVotes.status === 'error') {
+    return (
+      <Screen edges={NAVIGATOR_EDGES}>
+        <ErrorNote message={itemVotes.message} />
+      </Screen>
+    );
+  }
+
   if (view.items.length === 0) {
     return (
       <Screen edges={NAVIGATOR_EDGES}>
@@ -338,6 +460,11 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
       {orderedItems.map((item) => {
         const section = sectionForItemName(locationItems.items, item.name);
         const composing = composingItemId === item.id;
+        const correcting = correctingItemId === item.id;
+        const corrections =
+          section !== null
+            ? pendingCorrectionsForItemName(itemVotes.votes, item.name, section)
+            : [];
 
         return (
           <View key={item.id} style={styles.itemGroup}>
@@ -352,7 +479,43 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
 
             <View style={styles.tagRow}>
               {section !== null ? (
-                <Badge label={section} />
+                correcting ? (
+                  <View style={styles.tagComposer}>
+                    <Field
+                      label="New section"
+                      value={correctionDraft}
+                      onChangeText={setCorrectionDraft}
+                      placeholder={`Currently: ${section}`}
+                      autoCapitalize="sentences"
+                      autoFocus
+                      maxLength={60}
+                      editable={!pending.has(item.id)}
+                      onSubmitEditing={() => void submitCorrection(item)}
+                      returnKeyType="done"
+                    />
+                    <PrimaryButton
+                      label="Propose"
+                      onPress={() => void submitCorrection(item)}
+                      busy={pending.has(item.id)}
+                      disabled={correctionDraft.trim().length === 0}
+                    />
+                    <SecondaryButton
+                      label="Cancel"
+                      onPress={cancelCorrecting}
+                      disabled={pending.has(item.id)}
+                    />
+                  </View>
+                ) : (
+                  <View style={styles.tagBadgeRow}>
+                    <Badge label={section} />
+                    <IconButton
+                      glyph="✏"
+                      accessibilityLabel={`Propose a new location for ${item.name}`}
+                      onPress={() => beginCorrecting(item.id)}
+                      disabled={pending.has(item.id)}
+                    />
+                  </View>
+                )
               ) : composing ? (
                 <View style={styles.tagComposer}>
                   <Field
@@ -387,6 +550,22 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
                 />
               )}
             </View>
+
+            {corrections.length > 0 ? (
+              <View style={styles.pendingCorrections}>
+                {corrections.map((correction) => (
+                  <View key={correction.proposedSection} style={styles.pendingCorrectionRow}>
+                    <Body>{`Proposed new location: "${correction.proposedSection}"`}</Body>
+                    <PrimaryButton
+                      label="Confirm"
+                      onPress={() => void confirmCorrection(item, correction.proposedSection)}
+                      busy={pending.has(item.id)}
+                      disabled={pending.has(item.id)}
+                    />
+                  </View>
+                ))}
+              </View>
+            ) : null}
           </View>
         );
       })}
@@ -428,6 +607,20 @@ function createStyles(tokens: Tokens) {
       paddingLeft: tokens.minTouchTargetLarge,
     },
     tagComposer: {
+      gap: tokens.space.sm,
+    },
+    tagBadgeRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: tokens.space.sm,
+    },
+    pendingCorrections: {
+      paddingLeft: tokens.minTouchTargetLarge,
+      gap: tokens.space.xs,
+    },
+    pendingCorrectionRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
       gap: tokens.space.sm,
     },
   });

--- a/supabase/migrations/20260811000002_location_item_votes.sql
+++ b/supabase/migrations/20260811000002_location_item_votes.sql
@@ -1,0 +1,282 @@
+-- Slice 8 — Location Correction Voting.
+--
+-- `public.location_item_votes` is global in the same sense `public.location_items`
+-- (migration 20260811000000) and `public.location_checkoffs` (migration
+-- 20260811000001) are — no `household_id`, no `list_id` — but it is NOT
+-- attribution-free the way those two tables are. `voter_id` is a real, durable
+-- per-vote identity column, because this slice has a concrete functional need
+-- those two never had: telling a proposer apart from an *independent* second
+-- confirmer requires knowing, across two separate calls, whether the same person
+-- made both. The issue's acceptance test ("a second, independent user") cannot be
+-- checked without storing *some* identity per vote.
+--
+-- That identity is stored but never surfaced, mirroring `locations.created_by`
+-- (migration 20260810000005) rather than `location_items`' complete absence of a
+-- creator column. `location_items`' own header named store-and-withhold as the
+-- weaker of the two claims and chose the stronger one because it had no
+-- functional need for identity at all. This table does have that need, so it
+-- makes the weaker-but-still-real claim `locations` already established works:
+-- withheld from every SELECT grant below, never reachable through this table's
+-- own RLS policy, read only from inside this migration's own `security definer`
+-- function body. Nothing a client can query ever learns who proposed or
+-- confirmed a correction.
+--
+-- ONE table serves both "propose" and "confirm" — there is no separate
+-- corrections table. A "proposed correction" is not a first-class row; it is the
+-- distinct-values grouping of `(location_id, item_name, proposed_section)` that
+-- emerges from whichever vote rows currently exist. The first vote for a tuple
+-- that doesn't exist yet *is* the proposal; a second, independent vote for the
+-- same tuple *is* the confirmation. This follows 03-SPEC.md § 1's own sketch
+-- ("proposed correction → supporting user ids, until quorum") literally: one row
+-- per supporting user, not one row per proposal plus a separate collection of
+-- supporters.
+--
+-- A single item can therefore have more than one *different* proposed correction
+-- pending at once — two users independently deciding the same item moved, to two
+-- different new sections, without knowing about each other. Both are tracked as
+-- genuinely separate corrections, each needing its own independent quorum of 2.
+-- Nothing in this schema or the function below privileges one over the other or
+-- limits an item to one pending correction at a time.
+--
+-- `unique (location_id, item_name, proposed_section, voter_id)` is this slice's
+-- entire independence story, and it is a stronger guarantee than a runtime check
+-- could give: because a voter may appear at most once per tuple, any tuple that
+-- ever reaches two rows is *structurally* guaranteed to hold two distinct voters.
+-- There is no separate "is the confirmer different from the proposer" check
+-- anywhere in the function below, because the constraint already makes it
+-- impossible to construct a same-voter pair. A user's second attempt to vote for
+-- their own proposal (a second device, a second tab under the same anonymous
+-- identity, or literally re-tapping) collides with this constraint and is
+-- translated to a clear `already_voted` exception rather than silently
+-- succeeding — unlike `location_items`' own `tagItemLocation`, whose 23505
+-- leniency is *wrong* for this table specifically: a duplicate vote from the same
+-- user is not equivalent to a second independent vote reaching quorum, so
+-- treating it as silent success would mislead the user into believing the
+-- correction progressed when it did not.
+--
+-- Whoever's tag actually won `location_items`' own first-tag-wins race is
+-- unknowable — that table has no creator column at all — so there is no attempt
+-- anywhere in this slice to stop "the original tagger" from proposing a
+-- correction to their own tag. That is not a gap: it was never knowable, so it
+-- was never a real constraint to enforce.
+--
+-- `foreign key (location_id, item_name) references public.location_items
+-- (location_id, name) on delete cascade` — a single composite FK, not a separate
+-- plain FK to `locations(id)`. `location_items`' own `unique (location_id, name)`
+-- constraint (migration 20260811000000) is a valid FK target, and referencing it
+-- transitively guarantees `location_id` is also a real location
+-- (location_items.location_id already FKs to `locations(id)`), so a second,
+-- separate FK would only repeat a guarantee this one already gives. This also
+-- means "you may only vote on an item that is already tagged" is enforced at the
+-- schema level, not only inside the function below — cheap to have both. `on
+-- delete cascade` matches `location_items.location_id`'s own cascade reasoning: a
+-- vote for a tag that no longer exists is meaningless, not orphaned data worth
+-- preserving.
+--
+-- `item_name` repeats `location_items.name`'s exact normalization contract
+-- (`length between 1 and 120`, `= lower(btrim(name))`) for the same reason that
+-- column gives: it is a lookup/join key against `location_items.name`, not
+-- display text. `proposed_section` mirrors `location_items.section`'s own check
+-- (`length(trim(...)) between 1 and 60`) for the same reason that column gives:
+-- it is display-only text a shopper will eventually read as-is.
+--
+-- Proposing a `proposed_section` that exactly matches (after trim, case
+-- preserved) the item's *current* `location_items.section` is rejected outright
+-- (`correction_matches_current`) rather than accepted as a no-op vote — there is
+-- nothing to correct. The comparison is trim-only, not case-folded: a proposal
+-- that only fixes capitalization or spacing ("aisle 4" vs "Aisle 4") is a
+-- legitimate correction here, because unlike `name`, `section` has never had a
+-- case-folding contract anywhere in this schema.
+--
+-- No RLS INSERT/UPDATE/DELETE policy or grant on this table at all, deliberately
+-- stronger than `location_items`' "not built yet" stance. Every write happens
+-- exclusively inside `vote_location_item_correction`'s `security definer` body
+-- below, which runs with this migration's own privileges and is not subject to
+-- RLS or table grants. A policy permitting a direct client INSERT would let a
+-- client accumulate two independent voters' rows without ever running the
+-- quorum-check-and-apply step that only this function performs — nothing else in
+-- this schema watches this table for a quorum event, so a bypassed write path
+-- would leave a genuinely-reached quorum permanently unapplied. This is the "real
+-- atomicity/authorization invariant RLS can't express" bar every prior
+-- migration's header has cited (most recently 20260811000000's and
+-- 20260811000001's) — the first migration in this schema where that bar is
+-- actually met rather than ruled out.
+--
+-- For the same reason, `public.location_items` itself gets NO new UPDATE policy
+-- or grant in this migration, contradicting that table's own header comment
+-- ("Slice 8 will add an UPDATE policy for its correction mechanism"). That
+-- comment predated this design: an UPDATE policy reachable by any authenticated
+-- client would let anyone rewrite `section` directly, completely bypassing
+-- quorum. Instead, `location_items.section` is writable in exactly one place —
+-- inside the function below, which needs no grant to write a table the same role
+-- already owns, the same way `create_household`/`redeem_invite` (migration
+-- 20260810000000) write `households`/`household_members` with no grant beyond
+-- their own EXECUTE.
+--
+-- No new row in `supabase_realtime`'s publication membership — 0-for-3 so far
+-- (`locations`, `location_items`, `location_checkoffs` all opted out for the same
+-- reason) and this slice's acceptance test reads the same way: "User B ...
+-- confirms ... the tag now reflects the new location for all users" is satisfied
+-- by a fresh `ShoppingScreen` load, exactly like Slice 6's own acceptance test
+-- was, not by a live push mid-shop.
+--
+-- The function's parameters are prefixed `p_location_id`/`p_item_name`/
+-- `p_proposed_section`, matching `nearby_locations`' own prefix convention
+-- (migration 20260810000005) and for the identical reason that migration's header
+-- gives: the function body compares these against `location_items`' own
+-- `location_id`/`name` columns in bare, unqualified WHERE clauses, and an
+-- identically-named parameter would make that comparison ambiguously
+-- self-referential (or, worse, silently always-true) rather than raise an error —
+-- prefixing avoids the trap outright rather than relying on qualification
+-- discipline everywhere.
+--
+-- No extension operator is used anywhere below (plain uuid/text comparison and
+-- count(*) only), so the `set search_path = ''` trap `nearby_locations()` hit
+-- (migration 20260810000005's header — bare extension-provided operators don't
+-- resolve under a pinned empty search_path even when function calls do) does not
+-- apply here. Noted explicitly rather than silently assumed, per that migration's
+-- own warning.
+--
+-- Concurrency note on the apply step: two independent, truly concurrent
+-- confirmations landing on the same tuple (three or more distinct voters
+-- arriving within the same race window) can each independently observe "quorum
+-- reached" and both run the UPDATE + DELETE. This is safe, not merely tolerated:
+-- the UPDATE sets `section` to the same value both times (idempotent, and
+-- Postgres row-level locking serializes the two UPDATEs rather than corrupting
+-- either), and a second DELETE of an already-deleted tuple deletes zero rows
+-- without error. The one accepted, vanishingly rare edge case: a third voter's
+-- own INSERT can land in the narrow window between the winning pair's apply and
+-- its own quorum count, leaving that one vote row orphaned at count 1, pointing
+-- at a `proposed_section` that (by the time anyone reads it) already equals the
+-- new current value. It is inert, not incorrect — nobody can vote it to quorum in
+-- a way that changes anything, any *new* proposal for that item is still checked
+-- against the true current value, and the client-side
+-- `pendingCorrectionsForItemName` (mobile/src/lib/locationItemVotes.ts) filters
+-- out any group whose proposed value already equals the current one, so this
+-- orphan is never even rendered. Not otherwise engineered around: an advisory
+-- lock or `serializable` isolation to close a three-way race on a household
+-- grocery app is disproportionate to the cost of one harmless, invisible leftover
+-- row.
+
+create table public.location_item_votes (
+  id uuid primary key default gen_random_uuid(),
+  location_id uuid not null,
+  item_name text not null
+    check (length(item_name) between 1 and 120)
+    check (item_name = lower(btrim(item_name))),
+  proposed_section text not null
+    check (length(trim(proposed_section)) between 1 and 60),
+  voter_id uuid not null references auth.users (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (location_id, item_name, proposed_section, voter_id),
+  foreign key (location_id, item_name)
+    references public.location_items (location_id, name)
+    on delete cascade
+);
+
+-- No separate index on (location_id, item_name) or (location_id, item_name,
+-- proposed_section): the unique constraint above already creates a composite
+-- index with those as its leading columns, serving both this function's
+-- per-tuple count query and the client's per-location read
+-- (`loadLocationItemVotes`) exactly as well as a dedicated index would, for free
+-- — same reasoning as `location_items`' own single composite-index-does-double-
+-- duty note (migration 20260811000000).
+
+alter table public.location_item_votes enable row level security;
+
+create policy location_item_votes_select_all on public.location_item_votes
+  for select to authenticated
+  using (true);
+
+-- No insert/update/delete policy — see header: every write happens inside
+-- vote_location_item_correction()'s security-definer body, never through a
+-- client-facing policy.
+
+revoke all on table public.location_item_votes from anon, authenticated;
+
+grant select (id, location_id, item_name, proposed_section, created_at)
+  on table public.location_item_votes to authenticated;
+
+-- The one write path for this table and the one write path for
+-- `location_items.section`, both at once. See header for why this needs to be
+-- `security definer` rather than a plain RLS-gated INSERT: the atomic "add a
+-- vote, and if that just reached quorum, apply the correction and clear this
+-- item's votes" invariant spans two tables and cannot be expressed as a per-row
+-- `with check`.
+create or replace function public.vote_location_item_correction(
+  p_location_id uuid,
+  p_item_name text,
+  p_proposed_section text
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller uuid := (select auth.uid());
+  v_item_name text := lower(btrim(p_item_name));
+  v_proposed_section text := btrim(p_proposed_section);
+  v_current_section text;
+  v_vote_count int;
+begin
+  if caller is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  select section into v_current_section
+  from public.location_items
+  where location_id = p_location_id
+    and name = v_item_name;
+
+  if v_current_section is null then
+    raise exception 'item_not_tagged';
+  end if;
+
+  if v_current_section = v_proposed_section then
+    raise exception 'correction_matches_current';
+  end if;
+
+  -- The insert attempt IS the independence check — see header. Splitting a
+  -- pre-check from the write would let two truly concurrent identical requests
+  -- both pass the check before either wrote, the same race `redeem_invite`
+  -- (migration 20260810000000) already avoids by making its claiming UPDATE the
+  -- validation.
+  begin
+    insert into public.location_item_votes
+      (location_id, item_name, proposed_section, voter_id)
+    values
+      (p_location_id, v_item_name, v_proposed_section, caller);
+  exception when unique_violation then
+    raise exception 'already_voted';
+  end;
+
+  select count(*) into v_vote_count
+  from public.location_item_votes
+  where location_id = p_location_id
+    and item_name = v_item_name
+    and proposed_section = v_proposed_section;
+
+  if v_vote_count >= 2 then
+    update public.location_items
+    set section = v_proposed_section
+    where location_id = p_location_id
+      and name = v_item_name;
+
+    -- Every pending vote for this item, not only this tuple's own two — see
+    -- header's "applying one correction moots the others" decision. A sibling
+    -- proposal that was still short of quorum now points at a section that is
+    -- no longer current; keeping it around would be schema nobody reads, the
+    -- same bar `location_items`' own header cites from Slice 5's
+    -- `shop_sessions` reasoning.
+    delete from public.location_item_votes
+    where location_id = p_location_id
+      and item_name = v_item_name;
+  end if;
+end;
+$$;
+
+revoke execute on function public.vote_location_item_correction(uuid, text, text)
+  from public, anon;
+grant execute on function public.vote_location_item_correction(uuid, text, text)
+  to authenticated;

--- a/supabase/tests/rls_location_item_votes.sql
+++ b/supabase/tests/rls_location_item_votes.sql
@@ -1,0 +1,540 @@
+-- RLS/grant tests for public.location_item_votes and
+-- public.vote_location_item_correction (Slice 8 — Location Correction Voting).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- WHAT IT IS REALLY GUARDING. `public.location_item_votes` (migration
+-- 20260811000002) is the first table in this schema where every write is
+-- funnelled through one `security definer` function rather than direct-to-table
+-- RLS, so most of this file is about that function's behaviour rather than about
+-- policies. Assertions 0-1 establish the propose/confirm-is-just-two-votes core
+-- mechanic and that quorum (2 independent voters) actually applies the correction
+-- to `location_items.section` and clears the vote rows. Assertion 2 checks the
+-- `already_voted` rejection — the same voter cannot manufacture their own quorum.
+-- Assertion 3 checks a fresh, genuinely independent second voter succeeds where
+-- assertion 2's same-voter retry didn't. Assertions 4-5 check that two different
+-- proposed corrections for the same item can be pending independently, and that
+-- applying one via quorum wipes out the other's still-short-of-quorum vote row too
+-- (the "applying one correction moots the others" rule from the migration's own
+-- header). Assertion 6 checks `correction_matches_current` — proposing what is
+-- already true is rejected, not accepted as a no-op. Assertion 7 checks
+-- `item_not_tagged` — you cannot propose a correction for an item with no
+-- existing tag to correct. Assertion 8 checks no household is required to
+-- propose/confirm, matching every other table in this schema's "are you
+-- authenticated" bar. Assertion 9 checks `voter_id` is genuinely unreadable by a
+-- client — not merely undocumented — matching `locations.created_by`'s own
+-- withheld-column precedent. Assertion 10 checks there is no INSERT policy or
+-- grant at all on this table: every write must go through the function.
+-- Assertion 11 checks the composite foreign key does real work against a raw
+-- (bypass-role) insert. Assertion 12 checks that FK's `on delete cascade` actually
+-- fires. Assertion 13 checks the two check constraints (non-empty
+-- `proposed_section`, normalized `item_name`) do real enforcement work.
+--
+-- Fixtures are the premise, not the thing under test, so the location and
+-- location_items rows are inserted as the owning role, which bypasses RLS. Only
+-- the assertions run as `authenticated`. `request.jwt.claims` must be set
+-- *before* the role switch: after it, the session no longer has the privilege to
+-- set the GUC on some configurations, and auth.uid() reads that GUC.
+--
+-- State carries forward between assertions in this file — they are not
+-- independent and must not be reordered.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. E, F and G share nothing — no household, no prior relationship.
+-- One location L, created by E for convenience (created_by is not under test
+-- here). Two pre-tagged location_items rows at L: milk (Aisle 3) and bread
+-- (Aisle 1).
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-0000000000e8', true),  -- E
+  ('00000000-0000-4000-8000-0000000000f8', true),  -- F
+  ('00000000-0000-4000-8000-0000000000a8', true);  -- G
+
+insert into public.locations (id, name, lat, lng, created_by) values
+  ('81000000-0000-4000-8000-000000000001',
+   'Test Supermarket', -36.8485, 174.7633,
+   '00000000-0000-4000-8000-0000000000e8');
+
+insert into public.location_items (location_id, name, section) values
+  ('81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 3'),
+  ('81000000-0000-4000-8000-000000000001', 'bread', 'Aisle 1');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control. As E, propose a correction for milk. This is
+-- the first vote for the (milk, 'Aisle 7') tuple, so it must not reach quorum:
+-- a vote row must exist, and location_items.section for milk must be
+-- undisturbed.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 7');
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk'
+        and proposed_section = 'Aisle 7') <> 1 then
+    raise exception 'FAIL: E''s proposal for (milk, Aisle 7) did not create a visible vote row';
+  end if;
+
+  if (select section from public.location_items
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 3' then
+    raise exception 'FAIL: location_items.section for milk changed after a single vote — quorum of 1 should never apply a correction';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — THE core property: quorum. As F, an independent second voter
+-- for the same (milk, 'Aisle 7') tuple. Must succeed, must apply the
+-- correction, and must clear the vote rows for milk.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 7');
+
+  if (select section from public.location_items
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 7' then
+    raise exception 'FAIL: F''s independent second vote for (milk, Aisle 7) reached quorum but location_items.section was not updated';
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk') <> 0 then
+    raise exception 'FAIL: applying the (milk, Aisle 7) correction did not clear milk''s vote rows';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 2 — already_voted. E proposes a fresh tuple (milk, 'Aisle 12'),
+-- then immediately calls it again identically. The second call is the same
+-- voter re-voting the same tuple and must be rejected, not counted toward
+-- quorum.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+  msg text;
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 12');
+
+  begin
+    perform public.vote_location_item_correction(
+      '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 12');
+  exception when others then
+    raised := true;
+    msg := sqlerrm;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: E''s second identical vote for (milk, Aisle 12) succeeded — already_voted is not enforced';
+  end if;
+
+  if msg <> 'already_voted' then
+    raise exception 'FAIL: E''s rejected re-vote raised the wrong error (%) — expected already_voted', msg;
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk'
+        and proposed_section = 'Aisle 12') <> 1 then
+    raise exception 'FAIL: expected exactly 1 vote row for (milk, Aisle 12) after E''s rejected re-vote, not 0 or 2';
+  end if;
+
+  if (select section from public.location_items
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 7' then
+    raise exception 'FAIL: location_items.section for milk changed even though (milk, Aisle 12) never reached genuine quorum';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — a genuinely independent second voter succeeds where
+-- assertion 2's same-voter retry did not. As G (never voted on this tuple),
+-- confirm (milk, 'Aisle 12'). Must succeed and apply.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000a8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 12');
+
+  if (select section from public.location_items
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 12' then
+    raise exception 'FAIL: G''s genuinely independent second vote for (milk, Aisle 12) did not apply the correction';
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk') <> 0 then
+    raise exception 'FAIL: applying the (milk, Aisle 12) correction did not clear milk''s vote rows';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 4 — two different proposed corrections for the same item can be
+-- pending independently. F proposes (milk, 'Aisle 20'); G proposes
+-- (milk, 'Aisle 21') — two different fresh tuples, neither at quorum yet.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 20');
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000a8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 21');
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select section from public.location_items
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 12' then
+    raise exception 'FAIL: location_items.section for milk changed even though neither (milk, Aisle 20) nor (milk, Aisle 21) has reached quorum';
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk'
+        and proposed_section = 'Aisle 20') <> 1 then
+    raise exception 'FAIL: expected exactly 1 vote row for (milk, Aisle 20)';
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk'
+        and proposed_section = 'Aisle 21') <> 1 then
+    raise exception 'FAIL: expected exactly 1 vote row for (milk, Aisle 21)';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 5 — applying one correction moots the other. E casts the
+-- independent second vote for (milk, 'Aisle 20'), reaching quorum. Afterward,
+-- location_items.section must be 'Aisle 20', and ALL vote rows for milk must
+-- be gone — including the still-1-vote (milk, 'Aisle 21') proposal from
+-- assertion 4, which never itself reached quorum.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 20');
+
+  if (select section from public.location_items
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and name = 'milk') <> 'Aisle 20' then
+    raise exception 'FAIL: quorum was reached on (milk, Aisle 20) but location_items.section was not updated';
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk') <> 0 then
+    raise exception 'FAIL: applying the (milk, Aisle 20) correction did not clear ALL of milk''s vote rows — the still-pending (milk, Aisle 21) proposal was left behind';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 6 — correction_matches_current. F proposes (milk, 'Aisle 20'),
+-- which is now equal to the current section. Must be rejected outright, not
+-- accepted as a no-op vote.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+  msg text;
+begin
+  begin
+    perform public.vote_location_item_correction(
+      '81000000-0000-4000-8000-000000000001', 'milk', 'Aisle 20');
+  exception when others then
+    raised := true;
+    msg := sqlerrm;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: proposing a correction identical to milk''s current section succeeded — correction_matches_current is not enforced';
+  end if;
+
+  if msg <> 'correction_matches_current' then
+    raise exception 'FAIL: wrong error (%) raised for a no-op proposal — expected correction_matches_current', msg;
+  end if;
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'milk') <> 0 then
+    raise exception 'FAIL: a rejected correction_matches_current proposal left a vote row behind';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 7 — item_not_tagged. E proposes a correction for 'eggs', which
+-- has no location_items row at L at all. Must be rejected before any vote row
+-- or FK check is ever reached.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000e8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+  msg text;
+begin
+  begin
+    perform public.vote_location_item_correction(
+      '81000000-0000-4000-8000-000000000001', 'eggs', 'Aisle 5');
+  exception when others then
+    raised := true;
+    msg := sqlerrm;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: proposing a correction for an untagged item (eggs) succeeded — item_not_tagged is not enforced';
+  end if;
+
+  if msg <> 'item_not_tagged' then
+    raise exception 'FAIL: wrong error (%) raised for an untagged item — expected item_not_tagged', msg;
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 8 — no household required to propose/confirm. As F, who has no
+-- household at all, propose a correction for bread (currently 'Aisle 1').
+-- Must succeed and be visible.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  perform public.vote_location_item_correction(
+    '81000000-0000-4000-8000-000000000001', 'bread', 'Aisle 2');
+
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'bread'
+        and proposed_section = 'Aisle 2') <> 1 then
+    raise exception 'FAIL: F (no household at all) could not propose a correction for bread, or the resulting vote row is not visible';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 9 — voter_id is genuinely unreadable. As F, selecting voter_id
+-- off location_item_votes must raise a permission-denied error: that column
+-- is not in the SELECT grant.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    perform voter_id from public.location_item_votes where item_name = 'bread';
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: F could select voter_id off location_item_votes — this column must never be reachable by a client';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 10 — no INSERT policy or grant on this table at all. As F, a raw
+-- direct insert (bypassing the function entirely) must raise.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-0000000000f8","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_item_votes (location_id, item_name, proposed_section, voter_id)
+    values ('81000000-0000-4000-8000-000000000001', 'bread', 'Aisle 9',
+            '00000000-0000-4000-8000-0000000000f8');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: F could insert directly into location_item_votes — every write must go through vote_location_item_correction, never a direct table write';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 11 — the composite foreign key does real work. As the owning
+-- (bypass) role, inserting a vote for an item_name with no matching
+-- location_items row at L must raise a foreign-key violation.
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_item_votes (location_id, item_name, proposed_section, voter_id)
+    values ('81000000-0000-4000-8000-000000000001', 'nonexistent-item', 'Aisle 1',
+            '00000000-0000-4000-8000-0000000000e8');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: inserting a vote for an item with no matching location_items row succeeded — the composite foreign key (location_id, item_name) references location_items (location_id, name) is not enforced';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 12 — the composite foreign key's on delete cascade actually
+-- fires. As the owning (bypass) role, deleting bread's location_items row
+-- (which currently has the pending vote row from assertion 8) must take that
+-- vote row with it.
+-- ---------------------------------------------------------------------------
+
+delete from public.location_items
+where location_id = '81000000-0000-4000-8000-000000000001' and name = 'bread';
+
+do $$
+begin
+  if (select count(*) from public.location_item_votes
+      where location_id = '81000000-0000-4000-8000-000000000001'
+        and item_name = 'bread') <> 0 then
+    raise exception 'FAIL: deleting the bread location_items row left its pending vote row behind — on delete cascade on the composite foreign key is not working';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 13 — the two check constraints do real work. As the owning
+-- (bypass) role, against the still-existing milk row: (a) an empty
+-- proposed_section must raise; (b) an unnormalized item_name ('Milk') must
+-- raise.
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_item_votes (location_id, item_name, proposed_section, voter_id)
+    values ('81000000-0000-4000-8000-000000000001', 'milk', '',
+            '00000000-0000-4000-8000-0000000000e8');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: an empty proposed_section was accepted — the length(trim(proposed_section)) between 1 and 60 check constraint is not enforced';
+  end if;
+end $$;
+
+do $$
+declare
+  raised boolean := false;
+begin
+  begin
+    insert into public.location_item_votes (location_id, item_name, proposed_section, voter_id)
+    values ('81000000-0000-4000-8000-000000000001', 'Milk', 'Aisle 30',
+            '00000000-0000-4000-8000-0000000000e8');
+  exception when others then
+    raised := true;
+  end;
+
+  if not raised then
+    raise exception 'FAIL: an unnormalized item_name (''Milk'') was accepted — the item_name = lower(btrim(item_name)) check constraint is not enforced';
+  end if;
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #8.

## Summary
A user can propose a correction to an existing item-location tag; the correction does not take effect until a second, independent user confirms it at that location.

## Design
- `public.location_item_votes` (migration `20260811000002`): one row per supporting voter. No separate "proposal" row — the first vote for a `(location_id, item_name, proposed_section)` tuple *is* the propose; a second, independent vote *is* the confirm. `unique(location_id, item_name, proposed_section, voter_id)` makes independence structural, not a runtime check.
- `voter_id` is stored (needed to tell a proposer apart from an independent confirmer — a real functional need `location_items` never had) but withheld from every SELECT grant, mirroring `locations.created_by`'s precedent.
- `public.vote_location_item_correction()` is the sole write path for both this table and `location_items.section` — `security definer`, since applying a correction on quorum is a cross-table check-then-write RLS can't express. First table in this schema where that bar is actually met (every prior table used direct-to-table RLS writes).
- Two different proposed corrections for the same item can be pending at once, each with its own independent quorum of 2; applying one clears both (documented in the migration header).
- `mobile/src/lib/locationItemVotes.ts` / `mobile/src/hooks/useLocationItemVotes.ts` mirror `locationItems.ts`/`useLocationItems.ts`'s shape.
- `ShoppingScreen.tsx`: a tagged item's `Badge` gains a pencil `IconButton` to propose a correction; pending corrections render as a plain line + single-tap "Confirm" (not the `Confirm` card primitive — this system has no reject/veto verb).

## Testing checklist (from issue #8)
- [x] User A proposes a correction; the tag other users see is unchanged
- [x] User B (different household) confirms the same correction; the tag now reflects the new location for all users at that location

## Verification performed
- `npx tsc --noEmit` clean.
- `supabase/tests/rls_location_item_votes.sql` — 14 assertions (quorum application, `already_voted` rejection, two independent pending corrections coexisting + one applying clears both, `voter_id` unreadability, no direct-insert bypass, FK/cascade/check-constraint enforcement) — run clean against the live project, independently re-run and confirmed by the orchestrator, not just reported by the implementing agent.
- Live-verified against local dev with two genuinely distinct anonymous users (Browser pane + Claude-in-Chrome, confirmed differing `auth.uid()`s): user A proposed "Aisle 9" for an item tagged "Aisle 3" — the visible badge stayed "Aisle 3", and user A's own attempt to confirm their own proposal was rejected (`already_voted`, surfaced via the existing `ErrorNote` path). User B — a different list, different household, matching via lowercase "milk" to prove name-normalization — then confirmed independently; both sessions converged on "Aisle 9" after reload. Confirmed at the database level directly (`location_items.section = 'Aisle 9'`, zero pending `location_item_votes` rows).
- All test rows (2 anonymous users, 2 lists, 1 location, 1 location_items row) queried and confirmed as this session's own before deletion, then deleted and re-verified at zero.

`mobile/app.json` and `mobile/package.json` bumped to `0.0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)