### PR TITLE
Issue #23: Dashboard nearby-store nudge + pending corrections

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "light",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobile",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile",
-      "version": "0.0.9",
+      "version": "0.0.11",
       "dependencies": {
         "@expo/metro-runtime": "~57.0.8",
         "@react-native-async-storage/async-storage": "2.2.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/lib/locationItemVotes.ts
+++ b/mobile/src/lib/locationItemVotes.ts
@@ -136,6 +136,79 @@ export function pendingCorrectionsForItemName(
  * benign races the caller's own refresh already resolves; each means nothing
  * happened toward the correction the caller intended.
  */
+/** One location's count of distinct pending corrections — the Dashboard's
+ * (#23) "Pending corrections" widget. */
+export type PendingCorrectionCount = {
+  locationId: string;
+  count: number;
+};
+
+/**
+ * Counts distinct pending `(item_name, proposed_section)` corrections across
+ * several locations at once — `loadLocationItemVotes` above stays
+ * single-location because every existing caller (`ShoppingScreen`) already
+ * has exactly one location in view; the Dashboard is the first caller that
+ * needs several at once, for whichever locations the current household
+ * actually shops at.
+ *
+ * `location_item_votes` carries no household or user column at all (global,
+ * like `location_items` itself — 03-SPEC.md § 0's location-global/
+ * household-private separation), so "the current household's" pending
+ * corrections has no direct query. The caller is expected to pass the
+ * locations that are actually relevant to it (its lists' attached locations,
+ * its shop history) — this function just counts within whatever set it's
+ * given.
+ *
+ * Deliberately simpler than `pendingCorrectionsForItemName`: it does not
+ * filter out a proposal that already matches an item's *current* section.
+ * That filter needs each item's current `location_items.section`, which
+ * would mean loading every relevant location's full item set just to
+ * produce a dashboard summary count. `pendingCorrectionsForItemName`'s own
+ * doc comment already frames that race as rare and self-healing (the next
+ * vote or read clears it); a dashboard nudge that's very occasionally off
+ * by one during that window is an acceptable trade for not pulling in a
+ * second table's worth of data. The authoritative view stays
+ * `ShoppingScreen`, unaffected by this simplification.
+ */
+export async function loadPendingCorrectionCounts(
+  client: SupabaseClient,
+  locationIds: readonly string[],
+): Promise<Outcome<PendingCorrectionCount[]>> {
+  if (locationIds.length === 0) {
+    return { ok: true, value: [] };
+  }
+
+  const { data, error } = await client
+    .from('location_item_votes')
+    .select('location_id, item_name, proposed_section')
+    .in('location_id', locationIds);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  const rows = (data ?? []) as unknown as {
+    location_id: string;
+    item_name: string;
+    proposed_section: string;
+  }[];
+
+  const tuplesByLocation = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const tuples = tuplesByLocation.get(row.location_id) ?? new Set<string>();
+    tuples.add(`${row.item_name} ${row.proposed_section}`);
+    tuplesByLocation.set(row.location_id, tuples);
+  }
+
+  return {
+    ok: true,
+    value: Array.from(tuplesByLocation, ([locationId, tuples]) => ({
+      locationId,
+      count: tuples.size,
+    })),
+  };
+}
+
 export async function voteLocationItemCorrection(
   client: SupabaseClient,
   locationId: string,

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -20,12 +20,39 @@ import { DonutChart, type DonutSegment } from '../components/DonutChart';
 import type { ListsView } from '../hooks/useLists';
 import { useLocations } from '../hooks/useLocations';
 import { useShopSessions } from '../hooks/useShopSessions';
+import { requestLocation } from '../lib/geolocation';
 import type { Household } from '../lib/household';
 import { attachLocation, createList, loadInProgressListIds } from '../lib/lists';
+import {
+  loadPendingCorrectionCounts,
+  type PendingCorrectionCount,
+} from '../lib/locationItemVotes';
+import {
+  findNearbyLocations,
+  roundToNearest10,
+  type NearbyLocation,
+} from '../lib/locations';
 import { loadShopSessionLocationCounts, type LocationShopCount } from '../lib/shopSessions';
 import type { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../theme/ThemeProvider';
 import type { Tokens } from '../theme/tokens';
+
+/**
+ * How far "nearby" reaches for the #23 nudge — deliberately not
+ * `MERGE_RADIUS_M` (`locations.ts`, 100m): that constant answers "is this
+ * close enough to be the same physical store," a dedup check. This answers
+ * "close enough that starting a list here is worth suggesting," a walking
+ * distance. No spec value exists for this one; 200m is a plain judgement
+ * call, not a locked constant other code depends on.
+ */
+const NEARBY_STORE_RADIUS_M = 200;
+
+type NearbyState =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'denied' }
+  | { status: 'error'; message: string }
+  | { status: 'found'; results: NearbyLocation[] };
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Dashboard'> & {
   client: SupabaseClient;
@@ -36,21 +63,30 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Dashboard'> & {
 };
 
 /**
- * Home, as of #22. `Lists` held this role from Slice 2 through Slice 9; this
- * screen takes over, in the priority order the issue sets: new list,
- * continue shopping, store frequency, household snapshot, recent activity.
+ * Home, as of #22, with #23's two stretch widgets folded in afterward: a
+ * nearby-store nudge and a pending-corrections summary. Render order: new
+ * list, nearby stores, continue shopping, store frequency, pending
+ * corrections, household snapshot, recent activity — #22's five widgets in
+ * their original priority order, with #23's two slotted in near the
+ * shopping-action widgets they're closest in kind to (neither issue
+ * mandates exact placement for the stretch pair).
  *
- * Every section but "New list" and "Household snapshot" renders nothing
- * (not an empty card) when it has nothing to show — a dashboard that always
- * reserves space for five widgets regardless of data reads as broken on a
- * fresh account, and the issue's own acceptance test says as much for the
- * chart specifically ("a sane empty state, not an empty chart").
+ * Every section but "New list", "Nearby stores" and "Household snapshot"
+ * renders nothing (not an empty card) when it has nothing to show — a
+ * dashboard that always reserves space for every widget regardless of data
+ * reads as broken on a fresh account, and #22's acceptance test says as
+ * much for the chart specifically ("a sane empty state, not an empty
+ * chart"). "Nearby stores" is the deliberate exception: it's an on-demand
+ * action (the #23 Problem Agreement resolved the permission-prompt question
+ * as "a passive button, never an automatic check on load"), so the button
+ * itself has to stay visible for there to be anything to tap — what's
+ * conditional is only the *result* area below it, once checked.
  *
- * `inProgressListIds` and `locationCounts` are `null` while loading rather
- * than defaulting to empty — an empty *result* (genuinely no in-progress
- * lists) and a *not-yet-fetched* result would otherwise both render as "hide
- * this section," which very briefly hides a section on every dashboard
- * mount even for a household with real data.
+ * `inProgressListIds`, `locationCounts` and `pendingCorrections` are `null`
+ * while loading rather than defaulting to empty — an empty *result*
+ * (genuinely nothing to show) and a *not-yet-fetched* result would
+ * otherwise both render as "hide this section," which very briefly hides a
+ * section on every dashboard mount even for a household with real data.
  */
 export function DashboardScreen({
   client,
@@ -69,6 +105,14 @@ export function DashboardScreen({
   const [locationCounts, setLocationCounts] = useState<LocationShopCount[] | null>(null);
   const [busyLocationId, setBusyLocationId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingCorrections, setPendingCorrections] = useState<PendingCorrectionCount[] | null>(
+    null,
+  );
+  // Entirely separate from `error`/`busyLocationId` above, on purpose: a
+  // denied location permission has to stay scoped to this one widget and
+  // never touch any other section's state — #23's own testing checklist
+  // says so outright.
+  const [nearbyState, setNearbyState] = useState<NearbyState>({ status: 'idle' });
 
   const listIds = useMemo(
     () => (listsView.status === 'loaded' ? listsView.lists.map((l) => l.id) : []),
@@ -99,6 +143,49 @@ export function DashboardScreen({
   useEffect(() => {
     void refreshLocationCounts();
   }, [refreshLocationCounts]);
+
+  // The locations "the current household" has pending corrections at —
+  // location_item_votes carries no household/user column to ask directly
+  // (see loadPendingCorrectionCounts's own doc comment), so this is every
+  // location this account's own lists or shop history touch. Serialized to
+  // a sorted, deduped, comma-joined key so the effect below re-runs on a
+  // real change in membership, not on every new-but-equal array from the
+  // two useMemo/useState sources it's built from.
+  const relevantLocationIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (listsView.status === 'loaded') {
+      for (const list of listsView.lists) {
+        if (list.locationId) {
+          ids.add(list.locationId);
+        }
+      }
+    }
+    for (const entry of locationCounts ?? []) {
+      ids.add(entry.locationId);
+    }
+    return Array.from(ids).sort();
+  }, [listsView, locationCounts]);
+  const relevantLocationIdsKey = relevantLocationIds.join(',');
+
+  useEffect(() => {
+    // Waits for locationCounts to have loaded at least once — before that,
+    // relevantLocationIds only reflects list-attached locations, and
+    // running the (harmless but wasted) query against a known-partial set
+    // would just mean doing it again a moment later anyway.
+    if (locationCounts === null) {
+      return;
+    }
+    void (async () => {
+      const outcome = await loadPendingCorrectionCounts(client, relevantLocationIds);
+      if (outcome.ok) {
+        setPendingCorrections(outcome.value);
+      }
+    })();
+    // relevantLocationIds is read inside but intentionally not listed below
+    // — its array identity changes every render; relevantLocationIdsKey is
+    // the same information, stable across renders where membership hasn't
+    // changed, which is the condition that should actually re-run this.
+  }, [client, locationCounts, relevantLocationIdsKey]);
 
   // Catches the case a user checks off the last item on some other screen and
   // then comes back Home — `list_items` isn't subscribed here (see
@@ -173,6 +260,38 @@ export function DashboardScreen({
     navigation.navigate('ListDetail', { listId: newListId });
   }
 
+  /**
+   * Runs only on a tap — never on mount, never on focus. That's the whole
+   * resolution to #23's own open question: a location permission prompt is
+   * an interruption, and Home is the one screen guaranteed to be the first
+   * thing every session sees, so it's the one screen an automatic check
+   * would surprise on literally every cold open.
+   */
+  async function checkNearby() {
+    setNearbyState({ status: 'checking' });
+
+    const perm = await requestLocation();
+
+    if (perm.status === 'denied') {
+      setNearbyState({ status: 'denied' });
+      return;
+    }
+
+    if (perm.status === 'error') {
+      setNearbyState({ status: 'error', message: perm.message });
+      return;
+    }
+
+    const nearby = await findNearbyLocations(client, perm.lat, perm.lng, NEARBY_STORE_RADIUS_M);
+
+    if (!nearby.ok) {
+      setNearbyState({ status: 'error', message: nearby.message });
+      return;
+    }
+
+    setNearbyState({ status: 'found', results: nearby.value });
+  }
+
   const chartSegments: DonutSegment[] = (locationCounts ?? []).map((entry) => ({
     key: entry.locationId,
     label: locationName(entry.locationId),
@@ -200,6 +319,29 @@ export function DashboardScreen({
 
       <PrimaryButton label="New list" onPress={() => navigation.navigate('Lists')} />
 
+      <View style={styles.section}>
+        <Heading>Nearby stores</Heading>
+        {nearbyState.status === 'idle' ? (
+          <SecondaryButton label="Check for nearby stores" onPress={() => void checkNearby()} />
+        ) : nearbyState.status === 'checking' ? (
+          <ActivityIndicator color={tokens.color.accent} />
+        ) : nearbyState.status === 'denied' ? (
+          <Body>Location access isn't available, so nearby stores can't be checked this session.</Body>
+        ) : nearbyState.status === 'error' ? (
+          <ErrorNote message={nearbyState.message} />
+        ) : nearbyState.results.length === 0 ? (
+          <Body>No stores nearby right now.</Body>
+        ) : (
+          nearbyState.results.map((result) => (
+            <Row
+              key={result.id}
+              label={`${result.name} — ${roundToNearest10(result.distanceM)}m away`}
+              onPress={() => void startOrContinueAtLocation(result.id)}
+            />
+          ))
+        )}
+      </View>
+
       {inProgressLists.length > 0 ? (
         <View style={styles.section}>
           <Heading>Continue shopping</Heading>
@@ -225,6 +367,19 @@ export function DashboardScreen({
               onSegmentPress={(locationId) => void startOrContinueAtLocation(locationId)}
             />
           )}
+        </View>
+      ) : null}
+
+      {pendingCorrections !== null && pendingCorrections.length > 0 ? (
+        <View style={styles.section}>
+          <Heading>Pending corrections</Heading>
+          {pendingCorrections.map((entry) => (
+            <Row
+              key={entry.locationId}
+              label={`${locationName(entry.locationId)} · ${entry.count} waiting for a second vote`}
+              onPress={() => void startOrContinueAtLocation(entry.locationId)}
+            />
+          ))}
         </View>
       ) : null}
 


### PR DESCRIPTION
Resolves #23.

Two stretch widgets, added to `DashboardScreen` now that #22 is on `main`. `ready-for-human` on the original issue — resolved directly with the user before writing any code (see below), rather than guessing.

## Nearby-store nudge

Resolved the issue's own open question — running a location check on dashboard load, and the permission-prompt-on-open UX that implies — directly with the user first: **a passive "Check for nearby stores" button, never an automatic check on mount or focus.** Home is the one screen guaranteed to be the first thing every session sees, so it's the one screen an automatic permission prompt would surprise on literally every cold open. `LocationsScreen`'s existing one-off check is a deliberate ask on that specific screen, not a precedent to extend to Home.

Reuses `requestLocation()` (`geolocation.ts`) and `findNearbyLocations()` (`locations.ts`) exactly as `LocationsScreen` already does. New constant `NEARBY_STORE_RADIUS_M` (200m, local to `DashboardScreen`) rather than reusing `locations.ts`'s `MERGE_RADIUS_M` (100m) — that one answers "is this close enough to be a duplicate," this one answers "close enough to suggest," and no spec value ties them together.

Tapping a result reuses `startOrContinueAtLocation()` from #22 unchanged — same go-straight-to-an-existing-list-or-create-one behavior the store chart already has.

## Pending corrections

`location_item_votes` carries no household/user column at all (global table, mirrors `location_items` — `03-SPEC.md`'s location-global/household-private separation), so there's no direct query for "this household's" pending corrections. New `loadPendingCorrectionCounts()` (`locationItemVotes.ts`) is scoped by the caller instead: `DashboardScreen` passes every location its own lists or shop history touch.

Deliberately simpler than `pendingCorrectionsForItemName()` — it doesn't filter out a proposal that already matches an item's *current* section, which would need loading every relevant location's full item set just for a summary count. That existing function's own doc comment already frames the race as rare and self-healing; `ShoppingScreen` stays the authoritative, unaffected view.

Both widgets fail independently of the rest of the dashboard — a denied location permission only ever touches the nearby-nudge's own local state, never the shared `error`/`busy` state the other widgets' mutations use.

## Verification

Live-verified against the local dev DB, not just code review: seeded a location, an in-progress list at it, and a pending correction vote (via SQL, after confirming the test user owned nothing yet — same practice every prior slice used); mocked `navigator.geolocation`/`navigator.permissions.query` per this project's own documented web-preview trap for testing `expo-location`; confirmed the nudge found the seeded store at the right distance, tapping it went straight to the existing in-progress list, and the pending-corrections row showed the right count and navigated the same way. Also confirmed the plain-denial path (no mock) leaves every other widget intact. Deleted all seeded rows and re-verified zero afterward.

`npx tsc --noEmit` clean. `app.json`/`package.json` bumped to `0.0.11`.

## Testing checklist (from #23)

- [x] Nearby-store nudge appears only when a household member is genuinely near an existing location, and never when permission is denied or unavailable
- [x] Denying location permission from the dashboard doesn't block or degrade any other dashboard widget
- [x] Pending-corrections widget appears only when the current household/user has at least one unconfirmed correction outstanding
- [x] Both widgets are absent entirely (not shown empty) when there's nothing to surface — with the deliberate exception of the nearby-nudge's own button, which stays visible as the on-demand entry point (see `DashboardScreen`'s doc comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)