### PR TITLE
Batch A: #43, #40, #41, #37 — quick isolated UI fixes

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -279,6 +279,12 @@ function Bootstrapped({ env }: { env: Env }) {
  * `ShoppingScreen` overwrite via `navigation.setOptions({ title: ... })` once their
  * list loads. `headerTitleStyle` is gone because it only ever styled the default
  * text-based title, which nothing here still renders.
+ *
+ * `headerBackVisible: false` hides the native-stack back chevron on every screen —
+ * redundant next to the wordmark once the hamburger `NavMenu` covers the same
+ * "go somewhere else" job, and confusing sitting right beside a logo that isn't
+ * itself a button. This only hides the drawn button; it does not disable back
+ * navigation — the OS/browser back gesture and button still work exactly as before.
  */
 function headerOptions(tokens: Tokens) {
   return {
@@ -286,6 +292,7 @@ function headerOptions(tokens: Tokens) {
     headerTintColor: tokens.color.textPrimary,
     headerTitle: () => <HeaderLogo />,
     headerShadowVisible: false,
+    headerBackVisible: false,
     contentStyle: { backgroundColor: tokens.color.ground },
   };
 }

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -280,11 +280,18 @@ function Bootstrapped({ env }: { env: Env }) {
  * list loads. `headerTitleStyle` is gone because it only ever styled the default
  * text-based title, which nothing here still renders.
  *
- * `headerBackVisible: false` hides the native-stack back chevron on every screen —
- * redundant next to the wordmark once the hamburger `NavMenu` covers the same
- * "go somewhere else" job, and confusing sitting right beside a logo that isn't
- * itself a button. This only hides the drawn button; it does not disable back
- * navigation — the OS/browser back gesture and button still work exactly as before.
+ * `headerBackVisible: false` hides the native-stack back chevron — redundant next to
+ * the wordmark once the hamburger `NavMenu` covers the same "go somewhere else" job,
+ * and confusing sitting right beside a logo that isn't itself a button. It does not
+ * disable back navigation — the OS/browser back gesture and button still work
+ * exactly as before. It also does nothing at all on this project's actual review
+ * surface: `headerBackVisible` is only read by native-stack's *native* header path
+ * (`react-native-screens`, unavailable on web), not by the JS `Header` component
+ * `@react-navigation/elements` falls back to on web, which instead defaults
+ * `headerLeft` to a `HeaderBackButton` whenever `navigation.canGoBack()` is true,
+ * ignoring `headerBackVisible` entirely. `headerLeft: () => null` is the option the
+ * web fallback actually checks, so both are set — one per platform's real code path,
+ * neither one alone covers both.
  */
 function headerOptions(tokens: Tokens) {
   return {
@@ -293,6 +300,7 @@ function headerOptions(tokens: Tokens) {
     headerTitle: () => <HeaderLogo />,
     headerShadowVisible: false,
     headerBackVisible: false,
+    headerLeft: () => null,
     contentStyle: { backgroundColor: tokens.color.ground },
   };
 }

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/lib/buildInfo.ts
+++ b/mobile/src/lib/buildInfo.ts
@@ -1,6 +1,7 @@
 /**
- * Version + live/preview metadata for ListsScreen's footer. Nowhere else reads this
- * — see that screen's own comment for why the footer is scoped there and not global.
+ * Version + live/preview metadata for HouseholdScreen's footer. Nowhere else reads
+ * this — see that screen's own comment for why the footer is scoped there and not
+ * global.
  *
  * `appVersion` reads app.json's `expo.version` rather than package.json's. They're
  * kept in step by convention (bump both, see CHANGE-LOG.md), but app.json's is the

--- a/mobile/src/screens/HouseholdScreen.tsx
+++ b/mobile/src/screens/HouseholdScreen.tsx
@@ -24,9 +24,12 @@ import type { Tokens } from '../theme/tokens';
  * There is no "remove member" or "make admin" control, and that is not an omission:
  * every member is equal rank by spec, so there is no rank for a control to change.
  *
- * The household's name is missing here on purpose: the navigator header carries it,
- * because that header is also what carries back. Naming it twice on one screen was
- * what the header replaced.
+ * The household's name is missing here on purpose: it's still this screen's tab
+ * title (`Stack.Screen`'s own `title` in App.tsx), just no longer drawn in the
+ * header itself — the header shows the `HeaderLogo` wordmark instead of screen
+ * names, and its back chevron is suppressed in favor of the hamburger `NavMenu`
+ * (#41). Naming the household again here would only repeat what the tab title
+ * already carries, not fill a gap.
  */
 export function HouseholdScreen({
   client,

--- a/mobile/src/screens/HouseholdScreen.tsx
+++ b/mobile/src/screens/HouseholdScreen.tsx
@@ -12,6 +12,7 @@ import {
   SecondaryButton,
   SegmentedControl,
 } from '../components/ui';
+import { appVersion, buildChannel, buildChannelLabel } from '../lib/buildInfo';
 import { createInvite, type Invite } from '../lib/household';
 import { useTheme, useThemeMode } from '../theme/ThemeProvider';
 import type { Tokens } from '../theme/tokens';
@@ -99,6 +100,13 @@ export function HouseholdScreen({
           { value: 'system', label: 'System' },
         ]}
       />
+
+      {/* Just the last element in a normal flow — this screen doesn't scroll/
+          top-align like ListsScreen did, so there's no flexGrow bottom-pin trick to
+          replicate here. Scoped to this screen only — see buildInfo.ts for why. */}
+      <Text style={styles.footer}>
+        {`v${appVersion} · ${buildChannelLabel[buildChannel]}`}
+      </Text>
     </Screen>
   );
 }
@@ -136,6 +144,11 @@ function createStyles(tokens: Tokens) {
     expiry: {
       fontSize: tokens.fontSize.caption,
       color: tokens.color.textSecondary,
+    },
+    footer: {
+      fontSize: tokens.fontSize.caption,
+      color: tokens.color.textSecondary,
+      textAlign: 'center',
     },
   });
 }

--- a/mobile/src/screens/ListDetailScreen.tsx
+++ b/mobile/src/screens/ListDetailScreen.tsx
@@ -413,6 +413,7 @@ export function ListDetailScreen({
         editable={!busy}
         onSubmitEditing={() => add(items)}
         returnKeyType="done"
+        submitBehavior="submit"
       />
       <PrimaryButton
         label="Add"

--- a/mobile/src/screens/ListDetailScreen.tsx
+++ b/mobile/src/screens/ListDetailScreen.tsx
@@ -414,6 +414,7 @@ export function ListDetailScreen({
         onSubmitEditing={() => add(items)}
         returnKeyType="done"
         submitBehavior="submit"
+        blurOnSubmit={false}
       />
       <PrimaryButton
         label="Add"

--- a/mobile/src/screens/ListsScreen.tsx
+++ b/mobile/src/screens/ListsScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
@@ -16,7 +16,6 @@ import {
   SecondaryButton,
 } from '../components/ui';
 import type { ListsView } from '../hooks/useLists';
-import { appVersion, buildChannel, buildChannelLabel } from '../lib/buildInfo';
 import type { Household } from '../lib/household';
 import { createList } from '../lib/lists';
 import type { RootStackParamList } from '../navigation/types';
@@ -179,14 +178,6 @@ export function ListsScreen({
       ) : view.status === 'loaded' ? (
         <PrimaryButton label="New list" onPress={beginComposing} />
       ) : null}
-
-      {/* Pins to the visual bottom for a short list (flexGrow absorbs the leftover
-          space); trails after the last row instead once the list overflows the
-          screen. Scoped to this screen only — see buildInfo.ts for why. */}
-      <View style={styles.footerSpacer} />
-      <Text style={styles.footer}>
-        {`v${appVersion} · ${buildChannelLabel[buildChannel]}`}
-      </Text>
     </Screen>
   );
 }
@@ -195,14 +186,6 @@ function createStyles(tokens: Tokens) {
   return StyleSheet.create({
     composer: {
       gap: tokens.space.sm,
-    },
-    footerSpacer: {
-      flexGrow: 1,
-    },
-    footer: {
-      fontSize: tokens.fontSize.caption,
-      color: tokens.color.textSecondary,
-      textAlign: 'center',
     },
   });
 }

--- a/mobile/src/screens/LocationsScreen.tsx
+++ b/mobile/src/screens/LocationsScreen.tsx
@@ -238,7 +238,7 @@ export function LocationsScreen({ client, navigation, onListsChanged, route }: P
         label="Search locations"
         value={search}
         onChangeText={setSearch}
-        placeholder="Papanui PakNSave"
+        placeholder="e.g. Papanui PakNSave"
         autoCapitalize="none"
       />
 


### PR DESCRIPTION
Closes #43, closes #40, closes #41, closes #37.

Four small, independent, single-file fixes from the 2026-08-15 QA session (issues #32-#43), triaged and bundled into one PR per user's explicit choice (see the orchestrator-run Triage subagent's proposed batching, confirmed via AskUserQuestion this session).

## #43 — Add-item field loses focus after submit
`ListDetailScreen.tsx`'s "Add an item" field now has `submitBehavior="submit"` + `blurOnSubmit={false}`. Both are needed: `submitBehavior` covers a hypothetical future native run, but react-native-web 0.21.2 only respects `blurOnSubmit` for its own submit/blur logic — a real, live-verified finding from Code Review, not assumed.

## #40 — Location search placeholder reads as real data
`LocationsScreen.tsx`'s search field placeholder is now `"e.g. Papanui PakNSave"` — introduces an "e.g." convention to the app (none existed before) rather than removing the helpful example outright.

## #41 — Redundant back chevron next to header logo
`App.tsx`'s shared `headerOptions()` now sets both `headerBackVisible: false` (the native-stack-native option) **and** `headerLeft: () => null`. Both are required: `headerBackVisible` is a native-only construct never honored by the web build's `@react-navigation/elements` JS `Header` fallback, which unconditionally renders a `HeaderBackButton` whenever `canGoBack()` is true regardless of that option — confirmed live (found a real, still-visible chevron) and fixed via a second live-verification pass, not caught by static code review alone. OS/browser back gesture and `navigation.goBack()` are unaffected; only the drawn button is suppressed.

## #37 — Move version footer from Lists to Household screen
Moved from `ListsScreen.tsx` (removed, including now-dead `footerSpacer`/`footer` styles and the `Text` import) to `HouseholdScreen.tsx` (the "in a household" screen, not `HouseholdSetupScreen`). Renders as a normal last flow element rather than replicating the old flexGrow bottom-pin trick, since `HouseholdScreen` isn't a scrolling/top-aligned layout — confirmed this reads fine visually. `buildInfo.ts`'s doc comment updated to match.

## Testing — live-verified against a real seeded household/list/items (not just code review)
Ran the actual web build locally (`npx expo start --web`), created a real anonymous test household + personal list, and directly confirmed all four:
- **#43**: typed and submitted 3 items in a row ("Milk", "Eggs", "Bread") via Enter with zero re-taps of the field — field stayed focused and cleared each time, confirmed via `document.activeElement` + DOM value checks.
- **#40**: placeholder reads `"e.g. Papanui PakNSave"`, confirmed via the input's `placeholder` attribute.
- **#41**: confirmed **zero** back-link element in the DOM on Lists/ListDetail/Household (`document.querySelector('a[href="/"]')` → null) after the `headerLeft: () => null` fix — the first pass (`headerBackVisible: false` alone) was caught live as *not* actually working and fixed before merge.
- **#37**: confirmed `v0.0.13 · Dev` renders on Household screen and is absent (a stale hidden 0×0 leftover DOM node from React Navigation's stack retention aside) from the active Lists screen.

All test rows (1 anonymous user, 1 household, 1 list) queried and confirmed as this session's own before deletion, then deleted and reverified at zero.

`npx tsc --noEmit` clean throughout. `mobile/app.json`/`mobile/package.json` bumped to `0.0.13`.

Note on process: live browser verification in this PR was done directly by the orchestrator rather than a separate Verifier subagent — subagents in this session were confirmed to have no actual display/compositing access to the Browser pane (screenshot/interaction attempts failed with a 0×0 viewport), so the orchestrator ran the live-verification step itself. Flagging the deviation from the requested "separate Verifier subagent" plan rather than implying it ran as originally scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)