### PR TITLE
Batch B: Dashboard trims (#36, #38)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -187,8 +187,6 @@ function Bootstrapped({ env }: { env: Env }) {
               client={client}
               listsView={lists.view}
               onListsChanged={lists.refresh}
-              household={state.status === 'member' ? state.household : null}
-              memberCount={state.status === 'member' ? state.memberCount : 0}
             />
           )}
         </Stack.Screen>

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -21,7 +21,6 @@ import type { ListsView } from '../hooks/useLists';
 import { useLocations } from '../hooks/useLocations';
 import { useShopSessions } from '../hooks/useShopSessions';
 import { requestLocation } from '../lib/geolocation';
-import type { Household } from '../lib/household';
 import { attachLocation, createList, loadInProgressListIds } from '../lib/lists';
 import {
   loadPendingCorrectionCounts,
@@ -58,25 +57,23 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Dashboard'> & {
   client: SupabaseClient;
   listsView: ListsView;
   onListsChanged: () => Promise<void>;
-  household: Household | null;
-  memberCount: number;
 };
 
 /**
  * Home, as of #22, with #23's two stretch widgets folded in afterward: a
  * nearby-store nudge and a pending-corrections summary. Render order: new
  * list, nearby stores, continue shopping, store frequency, pending
- * corrections, household snapshot, recent activity — #22's five widgets in
- * their original priority order, with #23's two slotted in near the
- * shopping-action widgets they're closest in kind to (neither issue
- * mandates exact placement for the stretch pair).
+ * corrections, recent activity — #22's widgets in their original priority
+ * order, with #23's two slotted in near the shopping-action widgets they're
+ * closest in kind to (neither issue mandates exact placement for the
+ * stretch pair).
  *
- * Every section but "New list", "Nearby stores" and "Household snapshot"
- * renders nothing (not an empty card) when it has nothing to show — a
- * dashboard that always reserves space for every widget regardless of data
- * reads as broken on a fresh account, and #22's acceptance test says as
- * much for the chart specifically ("a sane empty state, not an empty
- * chart"). "Nearby stores" is the deliberate exception: it's an on-demand
+ * Every section but "New list" and "Nearby stores" renders nothing (not an
+ * empty card) when it has nothing to show — a dashboard that always
+ * reserves space for every widget regardless of data reads as broken on a
+ * fresh account, and #22's acceptance test says as much for the chart
+ * specifically ("a sane empty state, not an empty chart"). "Nearby stores"
+ * is the deliberate exception: it's an on-demand
  * action (the #23 Problem Agreement resolved the permission-prompt question
  * as "a passive button, never an automatic check on load"), so the button
  * itself has to stay visible for there to be anything to tap — what's
@@ -90,8 +87,6 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Dashboard'> & {
  */
 export function DashboardScreen({
   client,
-  household,
-  memberCount,
   navigation,
   listsView,
   onListsChanged,
@@ -383,25 +378,6 @@ export function DashboardScreen({
         </View>
       ) : null}
 
-      <View style={styles.section}>
-        <Heading>Household</Heading>
-        {household ? (
-          <Card>
-            <Text style={styles.householdName}>{household.name}</Text>
-            <Body>{`${memberCount} ${memberCount === 1 ? 'member' : 'members'}`}</Body>
-            <SecondaryButton label="Open household" onPress={() => navigation.navigate('Household')} />
-          </Card>
-        ) : (
-          <Card>
-            <Body>You're not in a household yet. Join or create one to share lists.</Body>
-            <SecondaryButton
-              label="Join or create a household"
-              onPress={() => navigation.navigate('HouseholdSetup')}
-            />
-          </Card>
-        )}
-      </View>
-
       {recentSessions.length > 0 ? (
         <View style={styles.section}>
           <Heading>Recent activity</Heading>
@@ -439,11 +415,6 @@ function createStyles(tokens: Tokens) {
   return StyleSheet.create({
     section: {
       gap: tokens.space.sm,
-    },
-    householdName: {
-      fontSize: tokens.fontSize.title,
-      fontWeight: '600',
-      color: tokens.color.textPrimary,
     },
   });
 }

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -335,6 +335,11 @@ export function DashboardScreen({
             />
           ))
         )}
+        {nearbyState.status === 'denied' ||
+        nearbyState.status === 'error' ||
+        nearbyState.status === 'found' ? (
+          <SecondaryButton label="Refresh" onPress={() => void checkNearby()} />
+        ) : null}
       </View>
 
       {inProgressLists.length > 0 ? (


### PR DESCRIPTION
## Summary

Batch B from the 2026-08-15 triage session — two independent Dashboard trims, batched into one PR because they both touch `DashboardScreen.tsx` in non-overlapping sections.

- Closes #36 — removes the "Household" card from the Dashboard (already reachable via the nav menu since #26's HeaderLogo/NavMenu work). Also removes the now-dead `household`/`memberCount` props, the `Household` type import, the bare `Text` import, and `styles.householdName`, plus the matching call-site props in `App.tsx`.
- Closes #38 — adds a manual "Refresh" `SecondaryButton` to the "Nearby stores" widget, shown whenever `nearbyState.status` is `denied`, `error`, or `found` (not `idle`/`checking`), so a stuck/stale check can be re-run without leaving/remounting the screen. `checkNearby()` needed no logic change — it already resets to `checking` on every call.

## Process

Ran the full pipeline per PROTOCOL.md: Planner → Code Writer → Code Reviewer (separate subagent session from Code Writer, per standing practice) → orchestrator did live-browser verification directly (subagents can't reach the Browser pane's compositing — a standing constraint documented since Batch A).

## Verification

- `npx tsc --noEmit` clean.
- Code Reviewer subagent (independent from the Code Writer) passed both issues with no findings.
- Live-verified in the real Browser pane against local dev (`mobile-web`, port 8082):
  - Loaded the Dashboard on a fresh anonymous no-household session — no Household card renders at all.
  - Clicked "Check for nearby stores" → landed on the `denied` state (browser's standard geolocation denial) → a "Refresh" button appeared as expected.
  - Clicked "Refresh" → the check re-ran and landed on `denied` again, with the Refresh button still present — confirms re-triggering works without leaving the screen.
- `mobile/app.json` and `mobile/package.json` bumped to `0.0.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)