### PR TITLE
Batch C: Finish shopping lifecycle (#33, #35)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -232,7 +232,12 @@ function Bootstrapped({ env }: { env: Env }) {
             replaces it with the list's name once the index resolves. */}
         <Stack.Screen name="Shopping" options={{ title: 'Shopping' }}>
           {(props) => (
-            <ShoppingScreen {...props} client={client} lists={lists.view} />
+            <ShoppingScreen
+              {...props}
+              client={client}
+              lists={lists.view}
+              onListsChanged={lists.refresh}
+            />
           )}
         </Stack.Screen>
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/lib/lists.ts
+++ b/mobile/src/lib/lists.ts
@@ -8,6 +8,7 @@ export type ListRow = {
   name: string;
   householdId: string | null;
   locationId: string | null;
+  archivedAt: string | null;
   createdAt: string;
 };
 
@@ -28,6 +29,7 @@ type ListRecord = {
   name: string;
   household_id: string | null;
   location_id: string | null;
+  archived_at: string | null;
   created_at: string;
 };
 
@@ -72,9 +74,15 @@ export async function loadLists(client: SupabaseClient): Promise<Outcome<ListRow
   // authorises each event against the SELECT policy evaluated on the *new* row, so a
   // policy saying `deleted_at is null` would suppress the very UPDATE that performs the
   // deletion. Filtering it here is the whole of the mechanism.
+  //
+  // `archived_at` gets no such filter — this function still returns archived lists.
+  // Whether an archived list belongs in a given screen's view is that screen's own
+  // question (`ListsScreen` filters its active view, `HistoryScreen` still wants to
+  // reach one) — the same reasoning as `locationId` being returned unfiltered even
+  // though not every screen cares whether a list has one.
   const { data, error } = await client
     .from('lists')
-    .select('id, name, household_id, location_id, created_at')
+    .select('id, name, household_id, location_id, archived_at, created_at')
     .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
@@ -91,6 +99,7 @@ export async function loadLists(client: SupabaseClient): Promise<Outcome<ListRow
       name: row.name,
       householdId: row.household_id,
       locationId: row.location_id,
+      archivedAt: row.archived_at,
       createdAt: row.created_at,
     })),
   };
@@ -199,6 +208,68 @@ export async function attachLocation(
     .from('lists')
     .update({ location_id: locationId })
     .eq('id', listId);
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: undefined };
+}
+
+/**
+ * Archives a list — called the moment `finishShopping()` succeeds. `value: true`
+ * means this call claimed it (`archived_at` was null and is now set by this call);
+ * `value: false` means it was already archived by an earlier call (this device's own
+ * retry, a second device, or a race) and nothing was written.
+ *
+ * The `.is('archived_at', null)` clause is not a convenience filter — it is the whole
+ * mechanism. Supabase executes the UPDATE and its `WHERE` clause as one statement, so
+ * "is it still unarchived" and "archive it" happen atomically at the database level;
+ * two concurrent `finishShopping()` calls for the same list can never both see
+ * `value: true`. `.select('id')` reads back which rows the UPDATE actually touched —
+ * empty means this call lost the race (or the list was already archived), not an
+ * error.
+ *
+ * `.eq('id', listId)` names the row; it does not authorise the write. The existing
+ * `lists_update_visible` policy already covers this column (see migration
+ * 20260817000000's header) — any household member may finish shopping and archive
+ * the list, not only its owner, matching 03-SPEC.md's "all members equal rank".
+ */
+export async function archiveList(
+  client: SupabaseClient,
+  listId: string,
+): Promise<Outcome<boolean>> {
+  const { data, error } = await client
+    .from('lists')
+    .update({ archived_at: new Date().toISOString() })
+    .eq('id', listId)
+    .is('archived_at', null)
+    .select('id');
+
+  if (error) {
+    return { ok: false, message: humanise(error) };
+  }
+
+  return { ok: true, value: (data ?? []).length > 0 };
+}
+
+/**
+ * Reverses `archiveList()` — used only as a compensating action when a write that
+ * was supposed to follow a successful archive claim (recording the checkoff/shop-
+ * session history) fails partway through, so the list becomes retryable again
+ * instead of silently and permanently losing that shop's history. Without this,
+ * a transient failure after a successful claim would leave the list archived
+ * forever with no history ever written, and every retry would read the claim as
+ * "already recorded" and skip straight to the success state.
+ *
+ * `.eq('id', listId)` names the row; it does not authorise the write. Same
+ * `lists_update_visible` coverage as `archiveList()` above.
+ */
+export async function unarchiveList(
+  client: SupabaseClient,
+  listId: string,
+): Promise<Outcome<void>> {
+  const { error } = await client.from('lists').update({ archived_at: null }).eq('id', listId);
 
   if (error) {
     return { ok: false, message: humanise(error) };
@@ -415,6 +486,11 @@ export async function setChecked(
  * "small dataset, reduce in JS" calls (`Screen`'s own doc comment on why a
  * grocery list doesn't need a `FlatList`). A household's full list set is
  * the same order of magnitude as one list's items.
+ *
+ * Callers are expected to exclude already-archived lists from `listIds`
+ * before calling this — "in progress" is meaningless for a list that has
+ * already been finished, and this function has no `archivedAt` of its own
+ * to check against (it only ever sees `list_items`, not `lists`).
  */
 export async function loadInProgressListIds(
   client: SupabaseClient,

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -109,8 +109,16 @@ export function DashboardScreen({
   // says so outright.
   const [nearbyState, setNearbyState] = useState<NearbyState>({ status: 'idle' });
 
+  // Archived lists (Batch C, #33) are excluded here, not just in ListsScreen's
+  // own view — loadInProgressListIds's own doc comment now says as much:
+  // "in progress" is meaningless for a list finishShopping() has already
+  // archived, and without this filter an already-archived list with leftover
+  // unchecked items would still resurface in "Continue shopping" forever.
   const listIds = useMemo(
-    () => (listsView.status === 'loaded' ? listsView.lists.map((l) => l.id) : []),
+    () =>
+      listsView.status === 'loaded'
+        ? listsView.lists.filter((l) => l.archivedAt === null).map((l) => l.id)
+        : [],
     [listsView],
   );
 

--- a/mobile/src/screens/ListDetailScreen.tsx
+++ b/mobile/src/screens/ListDetailScreen.tsx
@@ -474,13 +474,22 @@ export function ListDetailScreen({
             leading={
               <CheckTarget
                 checked={item.checkedAt !== null}
-                onToggle={() =>
+                onToggle={() => {
+                  // A finished shop (Batch C, #33) is read-only from here on —
+                  // this screen can still be reached for an archived list (a
+                  // deep link, or ShoppingScreen staying mounted underneath it
+                  // in the native-stack navigator per useListItems' own doc
+                  // comment), and its check state shouldn't drift after
+                  // finishShopping() already recorded it.
+                  if (list.archivedAt !== null) {
+                    return;
+                  }
                   void mutate(() =>
                     setChecked(client, item.id, item.checkedAt === null),
-                  )
-                }
+                  );
+                }}
                 accessibilityLabel={item.name}
-                disabled={busy}
+                disabled={busy || list.archivedAt !== null}
               />
             }
             trailing={

--- a/mobile/src/screens/ListsScreen.tsx
+++ b/mobile/src/screens/ListsScreen.tsx
@@ -99,7 +99,10 @@ export function ListsScreen({
     navigation.navigate('ListDetail', { listId: outcome.value });
   }
 
-  const lists = view.status === 'loaded' ? view.lists : [];
+  // Archived lists (Batch C, #33) are done — they're `finishShopping()`'s own
+  // record of a completed shop, not an active list to keep resurfacing here.
+  const lists =
+    view.status === 'loaded' ? view.lists.filter((list) => list.archivedAt === null) : [];
 
   return (
     <Screen edges={NAVIGATOR_EDGES} align="top" scroll>

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -29,7 +29,7 @@ import {
 } from '../lib/locationCheckoffs';
 import { sectionForItemName, tagItemLocation } from '../lib/locationItems';
 import { pendingCorrectionsForItemName, voteLocationItemCorrection } from '../lib/locationItemVotes';
-import { setChecked, type ListItemRow } from '../lib/lists';
+import { archiveList, setChecked, unarchiveList, type ListItemRow } from '../lib/lists';
 import { recordShopSession } from '../lib/shopSessions';
 import type { RootStackParamList } from '../navigation/types';
 import { useTheme } from '../theme/ThemeProvider';
@@ -38,6 +38,7 @@ import type { Tokens } from '../theme/tokens';
 type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
   client: SupabaseClient;
   lists: ListsView;
+  onListsChanged: () => Promise<void>;
 };
 
 /**
@@ -125,8 +126,40 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * with no matching session row), the same class of risk this project already
  * tolerates elsewhere — see Slice 4's accepted location-merge race window —
  * rather than a case worth an atomic function for.
+ *
+ * Batch C (#33 + #35) makes `finishShopping()` claim `list.archivedAt` via
+ * `archiveList()` (`../lib/lists`) as its very first write, before either of
+ * the two writes above. That claim is the actual duplicate-recording guard:
+ * `archiveList()`'s conditional UPDATE is atomic at the database level, so of
+ * two concurrent `finishShopping()` calls for the same list, only one can
+ * ever see `value: true` back. That caller alone proceeds to
+ * `recordLocationCheckoff`/`recordShopSession`; a caller that sees
+ * `value: false` (already archived — a race, a second device, or this
+ * device's own retry) skips straight to the finished-state UI instead of
+ * writing either row again. Archiving also feeds #33: `ListsScreen` and
+ * `DashboardScreen` both filter `archivedAt === null` into their active
+ * views, so a finished list drops out of "Lists" and "Continue shopping" the
+ * moment this write lands — hence the added `onListsChanged` prop, called
+ * after a real (not already-archived) finish, giving the Dashboard/Lists
+ * views this screen doesn't itself own a chance to refresh, rather than
+ * leaving them showing a now-archived list until their own next unrelated
+ * reload.
+ *
+ * If either `recordLocationCheckoff` or `recordShopSession` fails *after* a
+ * successful `value: true` claim, `finishShopping()` calls `unarchiveList()`
+ * (`../lib/lists`) as a best-effort compensating write before surfacing the
+ * error — without it, that failure would leave the list permanently archived
+ * with no history ever written, and every retry would read the stale claim as
+ * "already recorded" and silently skip the writes that never actually
+ * happened. A failure in the compensating unarchive itself is swallowed
+ * rather than shown, so it can never mask the real error that triggered it.
+ *
+ * Item check/uncheck (`toggle()`) is gated on `list.archivedAt` the same way
+ * the "Finish shopping" button already is — an archived list's item state is
+ * read-only from that point on, consistent with the "already recorded"
+ * messaging a returning visit to the same screen shows.
  */
-export function ShoppingScreen({ client, lists, navigation, route }: Props) {
+export function ShoppingScreen({ client, lists, navigation, onListsChanged, route }: Props) {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
   const { listId } = route.params;
@@ -174,6 +207,9 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
   }, [list, navigation]);
 
   async function toggle(item: ListItemRow) {
+    if (!list || list.archivedAt !== null) {
+      return;
+    }
     if (pending.has(item.id)) {
       return;
     }
@@ -332,6 +368,16 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     if (!list || list.locationId === null) {
       return;
     }
+    if (list.archivedAt !== null) {
+      // Can happen if the list was archived remotely (another device) while
+      // this device's confirm dialog was already open — the "Finish shopping"
+      // button itself is disabled once archivedAt is set, so this only ever
+      // catches a dialog that opened before that. Close it rather than leaving
+      // it stuck open with no feedback; the "already recorded" messaging
+      // (reads list.archivedAt directly) explains the rest.
+      setConfirmingFinish(false);
+      return;
+    }
     if (items.filter((item) => item.checkedAt !== null).length === 0) {
       return;
     }
@@ -341,10 +387,36 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
     setFinishingShopping(true);
     setError(null);
     try {
+      // The atomic claim. Only the caller that flips `archived_at` from null to
+      // non-null (`value: true`) is the one that actually gets to write the
+      // checkoff/session rows below — see this screen's own header comment for
+      // why this has to come first, and why it's this call, not either of the
+      // two below, that's the real duplicate-recording guard (#35).
+      const archiveOutcome = await archiveList(client, list.id);
+      if (!archiveOutcome.ok) {
+        setError(archiveOutcome.message);
+        return;
+      }
+
+      if (!archiveOutcome.value) {
+        // Already archived by an earlier call — this device's own retry, a
+        // second device, or a genuine race. The shop was already recorded;
+        // don't write either row again, just land on the same finished state.
+        setConfirmingFinish(false);
+        setJustFinished(true);
+        return;
+      }
+
       const checkedNames = orderedCheckedItemNames(items);
 
       const checkoffOutcome = await recordLocationCheckoff(client, list.locationId, checkedNames);
       if (!checkoffOutcome.ok) {
+        // The archive claim above already succeeded, so without this the list
+        // would be stuck permanently archived with no history ever written —
+        // undo the claim so the list stays retryable. Best-effort: a failure
+        // here doesn't get its own error message, so it can't mask the real
+        // one below.
+        await unarchiveList(client, list.id);
         setError(checkoffOutcome.message);
         return;
       }
@@ -357,11 +429,17 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
         checkedItemNames: checkedNames,
       });
       if (!sessionOutcome.ok) {
+        // Same compensating unarchive as above — the checkoff write already
+        // landed by this point, but the archive claim still needs to be
+        // undone so a retry doesn't skip straight to "already recorded"
+        // without a shop_sessions row ever existing.
+        await unarchiveList(client, list.id);
         setError(sessionOutcome.message);
         return;
       }
 
       await refreshCheckoffs();
+      await onListsChanged();
       setConfirmingFinish(false);
       setJustFinished(true);
     } finally {
@@ -499,7 +577,7 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
               label={item.name}
               checked={item.checkedAt !== null}
               onToggle={() => void toggle(item)}
-              disabled={pending.has(item.id)}
+              disabled={pending.has(item.id) || list.archivedAt !== null}
               accessibilityLabel={item.name}
             />
 
@@ -596,8 +674,12 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
         );
       })}
 
-      {justFinished ? (
-        <Body>Shop recorded — this location's ordering will reflect it next time.</Body>
+      {justFinished || list.archivedAt !== null ? (
+        <Body>
+          {justFinished
+            ? "Shop recorded — this location's ordering will reflect it next time."
+            : 'This shop has already been recorded.'}
+        </Body>
       ) : null}
 
       {confirmingFinish ? (
@@ -615,7 +697,7 @@ export function ShoppingScreen({ client, lists, navigation, route }: Props) {
             setError(null);
             setConfirmingFinish(true);
           }}
-          disabled={checkedCount === 0 || pending.size > 0}
+          disabled={checkedCount === 0 || pending.size > 0 || list.archivedAt !== null}
         />
       )}
     </Screen>

--- a/supabase/migrations/20260817000000_lists_archived_at.sql
+++ b/supabase/migrations/20260817000000_lists_archived_at.sql
@@ -1,0 +1,47 @@
+-- Batch C — "Finish shopping lifecycle" (#33 + #35): archiving a finished list.
+--
+-- Adds a single nullable `archived_at` timestamp to `lists`, set the moment
+-- `finishShopping()` succeeds. This is the one signal both halves of the batch need:
+-- `ListsScreen`'s active view filters it out (#33 — a finished list leaves the active
+-- Lists view), and `finishShopping()` treats a successful claim of this column
+-- (`archived_at` going from null to non-null) as the atomic gate that stops the same
+-- shop being recorded to history more than once (#35), racing devices included.
+--
+-- No new RLS policy. `lists_update_visible` (migration 20260810000003) already gates
+-- every UPDATE on this table by "owner or household member", evaluated via its
+-- `using`/`with check` pair — that predicate has no per-column awareness, so it
+-- already covers `archived_at` exactly as it covers `name`/`location_id`. The one
+-- thing a policy genuinely cannot do is what the column-level grant below does
+-- instead: switching a column on or off.
+--
+-- `archived_at` must NEVER be added to `lists_select_visible`, even for something that
+-- reads like "hide archived lists at the RLS layer instead of client-side." Realtime
+-- authorises each event against the subscriber's SELECT policy evaluated on the row's
+-- *new* values (Slice 2/3's own already-documented trap for `deleted_at`-style
+-- columns) — a policy filtering on `archived_at is null` would suppress the very
+-- UPDATE that performs the archiving, so no subscriber would ever see the row flip.
+-- Filtering archived lists out of the active view stays a client-side concern
+-- (`ListsScreen`/`DashboardScreen`), same as every other "which lists are these"
+-- proxy this codebase already carries.
+--
+-- No FK/cascade concerns — a plain timestamp, nothing to reference. No realtime-
+-- publication change needed either: `public.lists` is already published (migration
+-- 20260810000004), and publication membership tracks rows, not columns — a new
+-- column on an already-published table needs nothing further to propagate.
+--
+-- No RPC. Same precedent as `location_id` in 20260810000006: "may I write this list"
+-- is exactly `lists_update_visible`'s existing predicate, and the atomicity
+-- `finishShopping()` needs (claim the archive exactly once) comes from the
+-- application's own `.is('archived_at', null)` conditional UPDATE, not from anything
+-- only a `security definer` function could provide — a plain conditional UPDATE is
+-- already atomic at the database level.
+
+alter table public.lists
+  add column archived_at timestamptz;
+
+-- Same reasoning as every other column-level grant in this project (see
+-- 20260810000003's header): the blanket `revoke all` already ran when `lists` was
+-- created, so a newly added column starts with NO privilege, not an inherited one —
+-- this grant is the only thing that makes it writable at all, not an addition to an
+-- already-open door.
+grant update (archived_at) on table public.lists to authenticated;

--- a/supabase/tests/rls_lists_archived_at.sql
+++ b/supabase/tests/rls_lists_archived_at.sql
@@ -1,0 +1,227 @@
+-- RLS/grant tests for lists.archived_at (Batch C — "Finish shopping lifecycle", #33 + #35).
+--
+-- HOW TO RUN: paste this whole file into the Supabase MCP server's `execute_sql`
+-- tool against project chacavfoewyiwrfgvxtj, or into the dashboard SQL editor as a
+-- fallback. Success is silence: every assertion raises only when it fails, so a run
+-- that returns without a `FAIL:` exception is a pass. The whole file is wrapped in
+-- `begin ... rollback`, so it leaves nothing behind whether it passes or fails.
+--
+-- WHAT IT IS REALLY GUARDING. Migration 20260817000000 adds `lists.archived_at`
+-- without touching `lists_update_visible` — same claim as `location_id`
+-- (rls_lists_locations.sql) before it: the existing owner-or-household-member
+-- predicate already covers the new column with no policy change, and the
+-- column-level UPDATE grant added alongside it is what makes the column writable
+-- at all. Assertions 1-2 are the positive half (owner can archive; a household
+-- member who is NOT the owner can too, because 03-SPEC.md's "all members equal
+-- rank" applies here exactly as it does to check-off and to `location_id`);
+-- assertions 3-4 are the negative half (a household mate cannot reach a list
+-- outside their household, a stranger cannot reach either list). Assertion 5 is
+-- the one this file adds that `rls_lists_locations.sql` has no equivalent of: it
+-- proves the conditional-update guard `archiveList()` (`mobile/src/lib/lists.ts`)
+-- relies on for #35's duplicate-recording protection is atomic at the SQL level,
+-- independent of anything the application code does — a second `... where
+-- archived_at is null` UPDATE against an already-archived row affects zero rows,
+-- full stop, not because the client happened to check first.
+--
+-- Fixtures are the premise, not the thing under test, so they are inserted as the
+-- owning role, which bypasses RLS. Only the assertions run as `authenticated`.
+-- `request.jwt.claims` must be set *before* the role switch: after it, the session
+-- no longer has the privilege to set the GUC on some configurations, and auth.uid()
+-- reads that GUC.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. A and D share household H. B shares nothing with either of them.
+-- ---------------------------------------------------------------------------
+
+insert into auth.users (id, is_anonymous) values
+  ('00000000-0000-4000-8000-00000000006a', true),  -- A: household member, owns both lists below
+  ('00000000-0000-4000-8000-00000000006d', true),  -- D: same household as A, owns neither list
+  ('00000000-0000-4000-8000-00000000006b', true);  -- B: no household, no relation to A or D
+
+insert into public.households (id, name) values
+  ('50000000-0000-4000-8000-000000000002', 'Test Household (archived_at)');
+
+insert into public.household_members (user_id, household_id) values
+  ('00000000-0000-4000-8000-00000000006a', '50000000-0000-4000-8000-000000000002'),
+  ('00000000-0000-4000-8000-00000000006d', '50000000-0000-4000-8000-000000000002');
+
+insert into public.lists (id, owner_id, household_id, name) values
+  ('70000000-0000-4000-8000-000000000003',
+   '00000000-0000-4000-8000-00000000006a', null,
+   'A personal (archived_at test)'),
+  ('70000000-0000-4000-8000-000000000004',
+   '00000000-0000-4000-8000-00000000006a', '50000000-0000-4000-8000-000000000002',
+   'A household (archived_at test)');
+
+-- ---------------------------------------------------------------------------
+-- Assertion 0 — positive control, as A.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select count(*) from public.lists
+      where id in ('70000000-0000-4000-8000-000000000003',
+                    '70000000-0000-4000-8000-000000000004')) <> 2 then
+    raise exception 'FAIL: A cannot see A''s own two lists (policies hiding everything; the assertions below would prove nothing)';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 1 — owner A archives A's own personal list.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists
+  set archived_at = now()
+  where id = '70000000-0000-4000-8000-000000000003'
+    and archived_at is null;
+
+  if (select archived_at from public.lists
+      where id = '70000000-0000-4000-8000-000000000003') is null then
+    raise exception 'FAIL: A could not archive A''s own personal list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 2 — a household member who is NOT the owner (D) archives A's
+-- household-shared list too (equal-rank invariant).
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006d","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists
+  set archived_at = now()
+  where id = '70000000-0000-4000-8000-000000000004'
+    and archived_at is null;
+
+  if (select archived_at from public.lists
+      where id = '70000000-0000-4000-8000-000000000004') is null then
+    raise exception 'FAIL: D (household member, not owner) could not archive A''s household list — equal-rank invariant broken';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 3 — D, a household mate of A on the SHARED list, is not a member
+-- of A's PERSONAL list and cannot reach/archive it (already archived by
+-- assertion 1; D's attempt to null it back out must have zero effect).
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006d","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists
+  set archived_at = null
+  where id = '70000000-0000-4000-8000-000000000003';
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select archived_at from public.lists
+      where id = '70000000-0000-4000-8000-000000000003') is null then
+    raise exception 'FAIL: D un-archived A''s personal list''s archived_at — D can reach a list outside their household';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 4 — B, a stranger to both A and D, cannot reach or archive either
+-- list (attempts to null both back out; neither must move).
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006b","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  update public.lists set archived_at = null
+  where id = '70000000-0000-4000-8000-000000000003';
+
+  update public.lists set archived_at = null
+  where id = '70000000-0000-4000-8000-000000000004';
+end $$;
+
+reset role;
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+begin
+  if (select archived_at from public.lists
+      where id = '70000000-0000-4000-8000-000000000003') is null then
+    raise exception 'FAIL: B un-archived A''s personal list''s archived_at — a stranger reached a personal list';
+  end if;
+
+  if (select archived_at from public.lists
+      where id = '70000000-0000-4000-8000-000000000004') is null then
+    raise exception 'FAIL: B un-archived A''s household list''s archived_at — a stranger reached a household list';
+  end if;
+end $$;
+
+reset role;
+
+-- ---------------------------------------------------------------------------
+-- Assertion 5 — the conditional-update guard is atomic at the SQL level.
+-- A's personal list is already archived (assertion 1); the exact same
+-- `... where archived_at is null` UPDATE `archiveList()` runs, run again by
+-- its own owner, must affect zero rows — proving two concurrent
+-- finishShopping() calls can never both see themselves as the one that
+-- claimed the archive, independent of any application-level check.
+-- ---------------------------------------------------------------------------
+
+select set_config('request.jwt.claims',
+  '{"sub":"00000000-0000-4000-8000-00000000006a","role":"authenticated"}', true);
+set local role authenticated;
+
+do $$
+declare
+  affected int;
+begin
+  update public.lists
+  set archived_at = now()
+  where id = '70000000-0000-4000-8000-000000000003'
+    and archived_at is null;
+
+  get diagnostics affected = row_count;
+
+  if affected <> 0 then
+    raise exception 'FAIL: re-running the conditional archive UPDATE against an already-archived list affected % row(s), expected 0 — the atomic claim guard is broken', affected;
+  end if;
+end $$;
+
+reset role;
+
+rollback;


### PR DESCRIPTION
## Summary

Closes #33 and #35, following the batching plan set in the prior triage session.

- **#33** — a finished shopping list now leaves the active Lists view.
- **#35** — the same shop can no longer be recorded to `shop_sessions` history more than once.

Both are backed by a single nullable `lists.archived_at timestamptz` column, set the moment `finishShopping()` succeeds — matching this codebase's existing `checked_at`/`deleted_at` idiom rather than a status enum.

## Also fixed: a related gap flagged in triage, not silently left

`DashboardScreen.tsx`'s "Continue shopping" widget relied on `loadInProgressListIds()`'s proxy ("has at least one unchecked item"). Since `finishShopping()` only requires `checkedCount > 0` (not that everything is checked), a list finished with leftover unchecked items would have kept resurfacing on the Dashboard even after archiving landed. Fixed by excluding archived lists before computing "in progress" ids.

## Design notes

- `archiveList()` (`mobile/src/lib/lists.ts`) uses a conditional UPDATE (`.is('archived_at', null)`) as an atomic claim — this is what actually guarantees only one caller ever wins a race between concurrent `finishShopping()` calls for the same list, not just the UI-level double-tap guard that already existed.
- Write order in `finishShopping()` is archive-first, then `location_checkoffs`/`shop_sessions`. This closes the #35 race but opens a narrower one: if the history write fails after the archive claim succeeds (e.g. a network blip), the list would be permanently archived with no history. A code-review pass caught this; fixed with a compensating `unarchiveList()` call on failure, so the list becomes retryable again instead of silently losing that shop.
- Item check-off is now read-only once a list is archived (`ShoppingScreen.tsx` + `ListDetailScreen.tsx`, the latter reachable for an archived list via direct link or staying mounted under `ShoppingScreen` in the nav stack) — a second review finding, also fixed.
- The "Finish shopping" confirm dialog now closes itself if the list gets archived out from under it by another device mid-dialog — a third review finding, also fixed.
- `archived_at` is deliberately kept out of `lists_select_visible` and out of `loadLists()`'s own filtering — the former to avoid suppressing the Realtime UPDATE event that performs the archiving (this project's documented Realtime-authorization trap), the latter because `ShoppingScreen` still needs to resolve the list it just archived to show its own confirmation, and `DashboardScreen`'s fix above needs to see `archivedAt` on every row, not have archived rows silently absent.
- New `supabase/tests/rls_lists_archived_at.sql` (6 assertions) — includes a regression test proving the conditional-update guard is atomic at the SQL level, independent of application code. Ran clean against the live project.

## Two accepted, narrower edge cases (flagged by review, knowingly not engineered around further)

Consistent with this project's existing risk tolerance for rare multi-write races (see HANDOFF's notes on `shop_sessions`/`location_checkoffs` and the location-correction quorum vote):

1. If the compensating `unarchiveList()` call itself also fails (two consecutive network failures), the list can still end up permanently archived with no history.
2. A second device that loses the archive-claim race can show a stale "Shop recorded" message briefly if the winning device's write later fails and gets compensated.

## Process

Planner → Code Writer → Code Reviewer (separate session from Code Writer) → one fix-and-reverify round on the reviewer's 3 findings → orchestrator verification. **Live-browser verification was not performed this session** — the Browser pane was not displayed on the user's side and reported zero-size layout/compositing failures throughout, and the user explicitly opted to skip it rather than wait, given `npx tsc --noEmit` clean, the RLS test passing live, and two full review rounds. This is a deviation from the standing practice documented in HANDOFF.md for prior batches; flagging explicitly rather than implying it happened.

`mobile/app.json`/`mobile/package.json` bumped to `0.0.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)