### PR TITLE
Batch D: Finish-shopping toast (#34)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/components/ui.tsx
+++ b/mobile/src/components/ui.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -489,6 +489,54 @@ export function Confirm({
 }
 
 /**
+ * A high-visibility, in-flow confirmation — deliberately not an overlay, for the
+ * same reason Confirm above isn't one: react-native-web has no Alert, so anything
+ * that isn't rendered as part of the document never appears on the one verified
+ * surface. "Hard to miss" here comes from weight (icon, bold text, border,
+ * elevation), not from floating above the content.
+ *
+ * Positive-only for now (no `kind` prop) — the only caller today is a success
+ * confirmation, and adding negative/neutral kinds without a real second caller
+ * would be speculative. Color is never the only signal, matching ErrorNote's own
+ * rule: the check glyph carries the meaning, `positive` just accents it, and it's
+ * never used as a text-bearing fill (tokens.ts has no measured positiveWash to
+ * fill with).
+ *
+ * Dismiss is local-only and never wired back to caller state: tapping the "x"
+ * hides this instance for the rest of its mount but does not touch anything the
+ * caller passed in. No auto-dismiss timer — the one caller today (ShoppingScreen's
+ * `justFinished`) only ever flips true after the list is archived, and `toggle()`
+ * early-returns once a list is archived, so nothing in that screen resets
+ * `justFinished` back to false within a single mount. It persists until the
+ * screen unmounts by construction, not by a timer, so this component doesn't
+ * need one either.
+ */
+export function Banner({ message }: { message: string }) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <View accessibilityRole="alert" style={styles.banner}>
+      <Text style={styles.bannerGlyph}>✓</Text>
+      <Text style={styles.bannerText}>{message}</Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss confirmation"
+        onPress={() => setDismissed(true)}
+        style={({ pressed }) => [styles.touchTarget, pressed && styles.touchTargetPressed]}
+      >
+        <Text style={styles.iconGlyph}>×</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+/**
  * A small scope marker. The wash is decoration and the text is the information —
  * `accentWash` is too pale to carry meaning on its own, which is what its own token
  * comment says, so the label is ordinary primary text that happens to sit on it.
@@ -786,6 +834,30 @@ function createStyles(tokens: Tokens) {
     },
     confirmActions: {
       gap: tokens.space.sm,
+    },
+    banner: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: tokens.space.sm,
+      backgroundColor: tokens.color.surface,
+      borderRadius: tokens.radius.lg,
+      borderWidth: 2,
+      borderColor: tokens.color.positive,
+      padding: tokens.space.lg,
+      ...tokens.elevation.card,
+    },
+    bannerGlyph: {
+      color: tokens.color.positive,
+      fontSize: tokens.fontSize.title,
+      fontWeight: '700',
+      lineHeight: tokens.fontSize.title,
+    },
+    bannerText: {
+      flex: 1,
+      color: tokens.color.textPrimary,
+      fontSize: tokens.fontSize.body,
+      fontWeight: '600',
+      lineHeight: tokens.fontSize.body * 1.5,
     },
     badge: {
       alignSelf: 'flex-start',

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -5,6 +5,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
   Badge,
+  Banner,
   Body,
   CheckTarget,
   Confirm,
@@ -674,12 +675,10 @@ export function ShoppingScreen({ client, lists, navigation, onListsChanged, rout
         );
       })}
 
-      {justFinished || list.archivedAt !== null ? (
-        <Body>
-          {justFinished
-            ? "Shop recorded — this location's ordering will reflect it next time."
-            : 'This shop has already been recorded.'}
-        </Body>
+      {justFinished ? (
+        <Banner message="Shop recorded — this location's ordering will reflect it next time." />
+      ) : list.archivedAt !== null ? (
+        <Body>This shop has already been recorded.</Body>
       ) : null}
 
       {confirmingFinish ? (


### PR DESCRIPTION
## Summary

Fixes #34 — the "shop recorded" confirmation was a plain text line easy to walk away without noticing. Replaces it with a new `Banner` primitive: a bordered, elevated, icon-carrying in-flow confirmation.

## Design

- **New `Banner` component in `ui.tsx`**, not a toast/overlay library — deliberately in-flow, matching `Confirm`'s existing precedent (react-native-web has no `Alert`, so anything not rendered in the document never appears on this project's only verified surface).
- **No auto-dismiss timer.** `justFinished` already persists until the screen unmounts by construction (`toggle()` early-returns once the list is archived, so nothing resets it mid-mount) — an auto-hiding banner would *reduce* visibility versus today's persistent text, working against the issue's own ask ("before putting your phone away"). Manual dismiss (×) is local-only `Banner` state, never wired back into `ShoppingScreen`.
- **The "already recorded" (archived, not-just-finished) branch is untouched** — still plain `Body` text. Out of scope per the issue, which is specifically about the moment right after finishing a shop, not a returning visit to an already-archived list.
- Color is never the only signal (matches `ErrorNote`'s own rule) — the check glyph, bold text, border, and elevation all carry the message independent of the `positive` accent.

## Review

Planner → Code Writer → Code Reviewer (separate session, per this project's never-self-review rule) → one fix round on three findings (a doc comment citing a nonexistent explanation elsewhere, a non-contextual `accessibilityLabel="Dismiss"`, an alignment inconsistency vs. `ErrorNote`'s precedent) → re-verified clean by the same Reviewer session. Final verdict: ship.

## Verification

Live-verified in the real Browser pane against local dev (`mobile-web`, port 8082), with real seeded/cleaned-up test data — not just code review:
- Checked off an item, tapped "Finish shopping", confirmed → `Banner` renders with `role="alert"`, a green check glyph, bold confirmation text, and a working dismiss (`aria-label="Dismiss confirmation"`).
- Computed styles confirmed dark-theme `surface`/`positive` tokens applied correctly, 2px border, `radius.lg`, `elevation.card` shadow, and `alignItems: flex-start` (the review fix).
- Dismissing the banner removes only the banner — the disabled "Finish shopping" button and rest of the screen are unaffected.
- Re-checked at mobile width (375px) — banner and dismiss control both render without clipping.
- No new console errors introduced (one pre-existing, unrelated nested-button warning in `ListDetailScreen`'s `Row` was present before this change too — not touched by this PR).
- All test rows (2 lists, 2 `shop_sessions`, 2 `location_checkoffs`) queried and confirmed as this session's own before deletion, then deleted and reverified at zero.

One deviation flagged: didn't re-verify live that a full remount of the *specific* archived list still shows the plain `Body` "already recorded" text (no URL-based deep link back into an archived list once it's filtered out of the active `ListsScreen` view). That branch of the render is untouched from Batch C, and both the Code Writer and Reviewer independently traced why `justFinished` resets to `false` on remount.

`npx tsc --noEmit` clean throughout. `mobile/app.json`/`mobile/package.json` bumped to `0.0.16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)