### PR TITLE
Batch E: Self-explanatory aisle-tag affordance (#32)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/screens/ShoppingScreen.tsx
+++ b/mobile/src/screens/ShoppingScreen.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
@@ -159,6 +159,12 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Shopping'> & {
  * the "Finish shopping" button already is — an archived list's item state is
  * read-only from that point on, consistent with the "already recorded"
  * messaging a returning visit to the same screen shows.
+ *
+ * Batch E (#32) makes the untagged affordance self-explanatory: the bare `+`
+ * `IconButton` is replaced with a small labeled `Pressable` ("+ Tag aisle")
+ * in the accent color, so it reads as an action rather than stray
+ * punctuation. Presentational only — `beginTagging`, `composingItemId`, and
+ * the inline composer it opens are unchanged.
  */
 export function ShoppingScreen({ client, lists, navigation, onListsChanged, route }: Props) {
   const tokens = useTheme();
@@ -648,11 +654,15 @@ export function ShoppingScreen({ client, lists, navigation, onListsChanged, rout
                   />
                 </View>
               ) : (
-                <IconButton
-                  glyph="+"
+                <Pressable
+                  accessibilityRole="button"
                   accessibilityLabel={`Tag a section for ${item.name}`}
                   onPress={() => beginTagging(item.id)}
-                />
+                  style={({ pressed }) => [styles.tagPrompt, pressed && styles.tagPromptPressed]}
+                >
+                  <Text style={styles.tagPromptGlyph}>+</Text>
+                  <Text style={styles.tagPromptLabel}>Tag aisle</Text>
+                </Pressable>
               )}
             </View>
 
@@ -715,6 +725,30 @@ function createStyles(tokens: Tokens) {
     },
     tagComposer: {
       gap: tokens.space.sm,
+    },
+    tagPrompt: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: tokens.space.xs,
+      minHeight: tokens.minTouchTarget,
+      paddingHorizontal: tokens.space.sm,
+      borderRadius: tokens.radius.pill,
+      borderWidth: 1,
+      borderColor: tokens.color.border,
+    },
+    tagPromptPressed: {
+      backgroundColor: tokens.color.surfaceSunken,
+    },
+    tagPromptGlyph: {
+      color: tokens.color.accent,
+      fontSize: tokens.fontSize.body,
+      fontWeight: '700',
+      lineHeight: tokens.fontSize.body,
+    },
+    tagPromptLabel: {
+      color: tokens.color.accent,
+      fontSize: tokens.fontSize.caption,
+      fontWeight: '600',
     },
     tagBadgeRow: {
       flexDirection: 'row',


### PR DESCRIPTION
## Summary

Fixes #32 — the untagged-item "+" affordance in Shopping Mode was a bare, unlabeled `IconButton` that read as visual clutter rather than a recognizable feature. Replaces it with a small labeled `Pressable` ("+ Tag aisle") in the app's accent color.

Presentational only, standalone (no dependency on Batches C/D beyond sequencing to avoid touching the same file back-to-back). The underlying route-learning mechanism is untouched — it already learns store routes from check-off order; section tags are only a fallback for items never personally checked off at that location before.

## Design decision

Kept as local composition in `ShoppingScreen.tsx` rather than extending the shared `IconButton`/`Badge` primitives in `ui.tsx`:
- `IconButton` has a fixed-shape single-glyph contract used identically by 4 other call sites (nav menu, list reorder/remove, the correction pencil in this same file) — adding a label prop would dilute that contract for one caller.
- `Badge` is a pure-display "scope marker" used by 5 other call sites (Shared/Personal, Selected, recorded section) — making it pressable would conflate displaying a fact with creating one.
- A new shared primitive would be premature (YAGNI) for a single call site today.

## Known, deliberately-untouched gap

The new affordance carries forward the same pre-existing lack of a `pending`/`disabled` guard the old `IconButton` had — unlike the ✏ correction-pencil icon and the composer's Save/Cancel buttons in the same file, which do check `pending.has(item.id)`. Not introduced or worsened by this batch; flagged here as a possible separate follow-up rather than fixed inline (out of scope for a presentational-only fix).

## Process

Planner → Code Writer → Code Reviewer (separate subagent session) pipeline, matching Batches B–D. Reviewer found zero issues after checking: diff scope, token name resolution, call-site regressions (`IconButton`/`Badge` grep), accessibility label parity, the pre-existing-gap framing, layout/alignment under `tagRow`, version bumps, `tsc --noEmit`, doc-comment accuracy, and style/naming convention consistency.

`npx tsc --noEmit` clean (independently re-run by Code Writer and Code Reviewer). `mobile/app.json`/`mobile/package.json` bumped to `0.0.17`.

Live-browser verification to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)