### PR TITLE
Batch G: JWT blank-screen recovery (#42)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -9,7 +9,8 @@ import {
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
-import { Body, ErrorNote, Heading, Screen } from './src/components/ui';
+import { Body, ErrorNote, Heading, PrimaryButton, Screen } from './src/components/ui';
+import { AppErrorBoundary } from './src/components/ErrorBoundary';
 import { HeaderLogo } from './src/components/HeaderLogo';
 import { NavMenu } from './src/components/NavMenu';
 import { useAnonymousSession } from './src/hooks/useAnonymousSession';
@@ -78,7 +79,9 @@ export default function App() {
           it — including the branches that never reach the navigator. */}
       <SafeAreaProvider>
         {envResult.ok ? (
-          <Bootstrapped env={envResult.env} />
+          <AppErrorBoundary>
+            <Bootstrapped env={envResult.env} />
+          </AppErrorBoundary>
         ) : (
           <ConfigErrorScreen
             problem={envResult.problem}
@@ -158,6 +161,7 @@ function Bootstrapped({ env }: { env: Env }) {
         <Heading>Cartel can’t start</Heading>
         <Body>The app could not establish a session.</Body>
         <ErrorNote message={session.message} />
+        <PrimaryButton label="Try again" onPress={session.retry} />
       </Screen>
     );
   }
@@ -171,6 +175,7 @@ function Bootstrapped({ env }: { env: Env }) {
       <Screen>
         <Heading>Something went wrong</Heading>
         <ErrorNote message={view.message} />
+        <PrimaryButton label="Try again" onPress={refresh} />
       </Screen>
     );
   }

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cartel",
     "slug": "cartel",
     "scheme": "cartel",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "orientation": "portrait",
     "icon": "./assets/icon-light.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "main": "index.ts",
   "dependencies": {
     "@expo/metro-runtime": "~57.0.8",

--- a/mobile/src/components/ErrorBoundary.tsx
+++ b/mobile/src/components/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Platform } from 'react-native';
+
+import { Body, ErrorNote, Heading, PrimaryButton, Screen } from './ui';
+import { logDiagnostic } from '../lib/logging';
+
+type Props = { children: ReactNode };
+type State = { error: Error | null };
+
+/**
+ * Catches any uncaught render/effect-time exception anywhere below it (e.g. a JWT
+ * throw surfacing from Supabase internals) and shows a real recovery screen instead
+ * of the blank page #42 reports. Matches the visual pattern Bootstrapped's own
+ * session.status==='error' branch already uses (Screen/Heading/Body/ErrorNote).
+ * Not a root-cause fix — see #42 / HANDOFF.md.
+ */
+export class AppErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    logDiagnostic('error-boundary', error, { componentStack: info.componentStack });
+  }
+
+  private reload = (): void => {
+    if (Platform.OS === 'web') {
+      window.location.reload();
+      return;
+    }
+    // No page to reload on native, and no expo-updates dependency exists to add for
+    // this defensive-only batch. Clearing the caught error at least remounts the
+    // crashed subtree fresh, which is the closest native equivalent.
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <Screen>
+          <Heading>Cartel hit a snag</Heading>
+          <Body>Something went wrong. Reloading has cleared this every time so far.</Body>
+          <ErrorNote message={this.state.error.message} />
+          <PrimaryButton label="Reload" onPress={this.reload} />
+        </Screen>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/mobile/src/hooks/useAnonymousSession.ts
+++ b/mobile/src/hooks/useAnonymousSession.ts
@@ -1,10 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { logDiagnostic } from '../lib/logging';
+
+type InternalState =
+  | { status: 'loading' }
+  | { status: 'ready'; userId: string }
+  | { status: 'error'; message: string };
 
 export type SessionState =
   | { status: 'loading' }
   | { status: 'ready'; userId: string }
-  | { status: 'error'; message: string };
+  | { status: 'error'; message: string; retry: () => void };
 
 /**
  * Establishes the anonymous session the whole app runs on.
@@ -15,17 +22,26 @@ export type SessionState =
  *
  * Restoring matters more than creating: a restored session is what makes the user
  * the same person as last time, and therefore still in their household.
+ *
+ * `retry` (#42) re-runs the same establish effect via an internal token rather than
+ * reloading the page — a manual click, no backoff, no retry limit. It exists because
+ * the 'error' branch used to dead-end: nothing in the app could ever leave it short
+ * of an external reload.
  */
 export function useAnonymousSession(client: SupabaseClient): SessionState {
-  const [state, setState] = useState<SessionState>({ status: 'loading' });
+  const [state, setState] = useState<InternalState>({ status: 'loading' });
+  const [retryToken, setRetryToken] = useState(0);
+  const retry = useCallback(() => setRetryToken((n) => n + 1), []);
 
   useEffect(() => {
     let active = true;
+    setState({ status: 'loading' }); // resets the UI out of 'error' while retrying
 
     async function establish() {
       const { data, error } = await client.auth.getSession();
 
       if (error) {
+        logDiagnostic('session', error, { stage: 'getSession' });
         if (active) {
           setState({ status: 'error', message: error.message });
         }
@@ -46,6 +62,7 @@ export function useAnonymousSession(client: SupabaseClient): SessionState {
       }
 
       if (signIn.error) {
+        logDiagnostic('session', signIn.error, { stage: 'signInAnonymously' });
         setState({
           status: 'error',
           // Anonymous sign-in is a project-level toggle, and this is the error you
@@ -57,6 +74,7 @@ export function useAnonymousSession(client: SupabaseClient): SessionState {
       }
 
       if (!signIn.data.session) {
+        logDiagnostic('session', 'No session was returned.', { stage: 'signInAnonymously' });
         setState({ status: 'error', message: 'No session was returned.' });
         return;
       }
@@ -69,7 +87,7 @@ export function useAnonymousSession(client: SupabaseClient): SessionState {
     return () => {
       active = false;
     };
-  }, [client]);
+  }, [client, retryToken]);
 
-  return state;
+  return state.status === 'error' ? { ...state, retry } : state;
 }

--- a/mobile/src/hooks/useHousehold.ts
+++ b/mobile/src/hooks/useHousehold.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import { loadHouseholdState, type HouseholdState } from '../lib/household';
+import { logDiagnostic } from '../lib/logging';
 
 export type HouseholdView =
   | { status: 'loading' }
@@ -13,6 +14,10 @@ export function useHousehold(client: SupabaseClient, enabled: boolean) {
 
   const refresh = useCallback(async () => {
     const outcome = await loadHouseholdState(client);
+
+    if (!outcome.ok) {
+      logDiagnostic('household', outcome.message);
+    }
 
     setView(
       outcome.ok

--- a/mobile/src/lib/logging.ts
+++ b/mobile/src/lib/logging.ts
@@ -1,0 +1,25 @@
+/**
+ * Diagnostic logging for #42 ("JWT blank-screen recovery") — a defensive-recovery
+ * batch, not a root-cause fix. The reported bug "isn't reliably reproducible," so the
+ * point of this function is to make the next occurrence greppable (a consistent
+ * `[cartel:<scope>]` prefix, a JSON body with a timestamp and an `isJwtShaped` flag)
+ * rather than to diagnose anything now. This project has no telemetry/logging
+ * service, so plain `console.error` is the proportionate choice — not a placeholder
+ * for a real logging library that never got wired up.
+ */
+export function logDiagnostic(
+  scope: string,
+  subject: unknown,
+  extra?: Record<string, unknown>,
+): void {
+  const message = subject instanceof Error ? subject.message : String(subject);
+  console.error(
+    `[cartel:${scope}]`,
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      message,
+      isJwtShaped: /jwt/i.test(message),
+      ...extra,
+    }),
+  );
+}

--- a/mobile/src/lib/supabase.ts
+++ b/mobile/src/lib/supabase.ts
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 import { type Env } from './env';
+import { logDiagnostic } from './logging';
 
 /**
  * The app's Supabase client.
@@ -30,6 +31,16 @@ export function getSupabaseClient(env: Env): SupabaseClient {
         autoRefreshToken: true,
         detectSessionInUrl: false,
       },
+    });
+
+    // #42's "catch it in the act" monitoring — logs every auth state transition
+    // (including token-refresh failures) so a future occurrence of the reported JWT
+    // error has a trail to grep for, without adding a telemetry dependency.
+    client.auth.onAuthStateChange((event, session) => {
+      logDiagnostic('auth-state', event, {
+        hasSession: session !== null,
+        userId: session?.user.id ?? null,
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
Closes #42. Defensive recovery only — **not** a root-cause fix for the underlying JWT error, which remains unreproduced and undiagnosed. Adds three things:

1. **Crash net**: a new `AppErrorBoundary` (class component, `mobile/src/components/ErrorBoundary.tsx`) wraps only the `Bootstrapped` branch in `App.tsx` (not `ConfigErrorScreen`). Any uncaught render/effect exception anywhere in that subtree now shows a real "Cartel hit a snag" recovery screen with a Reload button, instead of the blank page the issue reports. This is the most likely actual mechanism behind #42 — the two *known* error branches (`useAnonymousSession`, `useHousehold`) already rendered real screens; a truly blank page implies an *unhandled* throw somewhere else in the tree, which nothing previously caught.
2. **Manual retry**: both pre-existing error branches in `Bootstrapped` (`session.status === 'error'`, `view.status === 'error'`) get a "Try again" button. Session retry re-runs `useAnonymousSession`'s effect via an internal retry-token (no page reload); household retry reuses the hook's existing `refresh()`. No automatic/silent retry, no backoff, no retry limit — every retry here is a manual click.
3. **Logging**: a new shared `logDiagnostic(scope, subject, extra)` helper (`mobile/src/lib/logging.ts`) — plain `console.error` with a `[cartel:<scope>]` prefix and a JSON body including an `isJwtShaped` flag — called from the error boundary's `componentDidCatch`, both `useAnonymousSession` error paths, `useHousehold`'s error path, and a new `client.auth.onAuthStateChange` listener in `supabase.ts` that logs every auth transition. This is what a future session needs to actually catch the real JWT error "in the act," per the issue's own text.

## Explicitly out of scope
- Diagnosing or fixing the actual JWT error.
- Any automatic/silent retry loop, backoff, or retry limit.
- Any change to `autoRefreshToken` / `persistSession` / `detectSessionInUrl`.
- Any new logging/telemetry dependency (no Sentry etc. exists in this codebase — plain `console.error` is the proportionate choice) or `expo-updates` dependency.

## Pipeline
Planner → Code Writer → Code Reviewer (separate subagent session, zero findings on first pass) → orchestrator live-browser verification.

## Live verification (real Browser pane, local dev, port 8082)
All three recovery paths exercised for real, not just read in source — via temporary, fully-reverted test-only edits (confirmed `git diff` clean before/after, `npx tsc --noEmit` clean):
- **Error boundary**: injected a real throw in `Bootstrapped` → confirmed the "Cartel hit a snag" screen rendered (not blank), full component stack logged via `[cartel:error-boundary]`, clicking Reload triggered a real full-page reload (confirmed via a second, later-timestamped `componentDidCatch` log entry), and removing the crash condition let the app recover to a normal working Dashboard.
- **Session retry**: forced `useAnonymousSession` into its error branch → confirmed "Try again" re-ran the effect client-side (state advanced attempt 0 → 1, no page reload) and logged via `[cartel:session]`.
- **Household retry**: forced `useHousehold`'s error branch → confirmed "Try again" called `refresh()` (state advanced attempt 1 → 2) and logged via `[cartel:household]`.
- **Auth-state logging**: confirmed `[cartel:auth-state]` lines (`INITIAL_SESSION`, `SIGNED_IN`) appear on a normal fresh load, with no PII beyond the user id already visible elsewhere in the app.

`mobile/app.json` / `mobile/package.json` bumped `0.0.18` → `0.0.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)